### PR TITLE
dmg-calc: fix CB to ignore negative phys res (no vulnerability boost)

### DIFF
--- a/dmg-calc.html
+++ b/dmg-calc.html
@@ -822,12 +822,14 @@
 		// 7. Physical resistance
 		const effRes      = mobRes - gearRes - amp - bcry;
 		const resMult     = (100 - effRes) / 100;
+		// CB is only reduced by positive phys res; negative phys res (vulnerability) does not boost CB
+		const cbResMult   = (100 - Math.max(0, effRes)) / 100;
 
 		// 8. Effective damage after phys res
 		const effMin      = Math.floor(finalMin * resMult);
 		const effMax      = Math.floor(finalMax * resMult);
 		const effAvg      = finalAvg * resMult;
-		const effCBAvg    = avgCB * resMult;
+		const effCBAvg    = avgCB * cbResMult;
 		const totalAvg    = effAvg + effCBAvg;
 
 		// 9. DPS


### PR DESCRIPTION
## Summary
- Crushing Blow (CB) is now only reduced by **positive** physical resistance
- Negative effective phys res (e.g. monster vulnerability from Amp Damage, gear, etc.) no longer incorrectly boosts CB damage
- Uses `Math.max(0, effRes)` when computing the CB resistance multiplier

Fixes #7

## Test plan
- [ ] Set mob phys res to a positive value (e.g. 50%) — CB should be reduced accordingly
- [ ] Set effective phys res to a negative value (e.g. -15% via Amp Damage) — CB should remain at base value (not boosted)
- [ ] Verify normal/weapon damage is still correctly boosted by negative phys res (only CB is capped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)