### PR TITLE
tier-lists: extract solo data to JSON, add spin-the-wheel

### DIFF
--- a/group-data.js
+++ b/group-data.js
@@ -1,0 +1,402 @@
+window.groupData = {
+  "season": 13,
+  "updatedDate": "March 23rd 2026",
+  "bannerText": "Currently, this is just a copy from Season 12",
+  "generalists": {
+    "title": "Public Map Focused P8 Mapping",
+    "descriptions": [
+      "Early season public map games tend to lean Elemental. Late season giga-physical builds show up.",
+      "The following builds can play well with and/or buff both Physical or Elemental teams.",
+      "Summon builds perform well in public games because of the safety wall they provide."
+    ],
+    "note": "NOTE! This is not Tiered or ordered, and some builds can shine in physical more than elemental and vice versa.",
+    "builds": [
+      {
+        "buildName": "Summons",
+        "className": "Druid",
+        "tableClass": "table-druid",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Summon Wall", "style": "secondary"},
+          {"text": "HOW", "style": "success"}
+        ],
+        "notes": [
+          {"text": "Raven - Eaglehorn", "style": "secondary"},
+          {"text": "Bear - Den Mother", "style": "secondary"},
+          {"text": "Wolf - Fenris", "style": "secondary"}
+        ]
+      },
+      {
+        "buildName": "Spirits + Vines",
+        "className": "Druid",
+        "tableClass": "table-druid",
+        "roles": [
+          {"text": "HOW", "style": "success"},
+          {"text": "OAK", "style": "success"},
+          {"text": "Worms", "style": "success"}
+        ],
+        "notes": [
+          {"text": "Z-DPS", "style": "secondary", "pill": false},
+          {"text": "Spirit Keeper", "style": "secondary", "pill": false},
+          {"text": "2 x Oak for Elemental Groups", "style": "secondary", "pill": false},
+          {"text": "Huge Party Sustain", "style": "secondary", "pill": false}
+        ]
+      },
+      {
+        "buildName": "Phoenix Strike",
+        "className": "Assassin",
+        "tableClass": "table-assassin",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Tail (Fire Kick) Astreons",
+        "className": "Assassin",
+        "tableClass": "table-assassin",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Static Leap Attack + Big Shouts",
+        "className": "Barbarian",
+        "tableClass": "table-barbarian",
+        "roles": [
+          {"text": "CC", "style": "warning"}
+        ],
+        "notes": [
+          {"text": "Stormlash or Schafers + Twlight + Ttians grip + Cyclopean + Gorefoot", "style": "secondary", "pill": false}
+        ]
+      },
+      {
+        "buildName": "Whirlwind + Shouts",
+        "className": "Barbarian",
+        "tableClass": "table-barbarian",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": [
+          {"text": "Static Proc", "style": "secondary", "pill": false}
+        ]
+      },
+      {
+        "buildName": "Decoy & Valks",
+        "className": "Amazon",
+        "tableClass": "table-amazon",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Summon Wall", "style": "secondary"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Multi Shot",
+        "className": "Amazon",
+        "tableClass": "table-amazon",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Strafe",
+        "className": "Amazon",
+        "tableClass": "table-amazon",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Hybrid Curse + Summons",
+        "className": "Necromancer",
+        "tableClass": "table-necro",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Summon Wall", "style": "secondary"},
+          {"text": "Curse", "style": "warning"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Giga Curse",
+        "className": "Necromancer",
+        "tableClass": "table-necro",
+        "roles": [
+          {"text": "Curse", "style": "warning"}
+        ],
+        "notes": [
+          {"text": "Z-DPS", "style": "secondary", "pill": false}
+        ]
+      },
+      {
+        "buildName": "Vengeance",
+        "className": "Paladin",
+        "tableClass": "table-paladin",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Aura", "style": "success"}
+        ],
+        "notes": [
+          {"text": "Conviction", "style": "secondary"}
+        ]
+      },
+      {
+        "buildName": "Holy Fire - Charge (HOJ + 2x Dragon)",
+        "className": "Paladin",
+        "tableClass": "table-paladin",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Aura", "style": "success"}
+        ],
+        "notes": [
+          {"text": "Conviction", "style": "secondary"}
+        ]
+      }
+    ]
+  },
+  "physical": {
+    "title": "Physical Focused P8 Mapping",
+    "descriptions": [
+      "Recommended to have a Buff Barbarian. Recommended to get all Physical auras via Paladin or Mercenary. Recommended all necros to be Curse hybrid. All spare mercs should be A1 Physical Demonmachine.",
+      "Scaling deadly strike is crucial. Only review tooltip damage with all party buffs active!"
+    ],
+    "note": "NOTE! Must have summons for T4. Necro summons are not advised, low Psn res and die fast.",
+    "classBuilds": {
+      "Sorceress": [
+        {
+          "buildName": "Dual Enchant & A1 Innocence Demonmachine",
+          "tier": "Good",
+          "roles": [
+            {"text": "T4", "style": "dark"},
+            {"text": "Enchant", "style": "success"},
+            {"text": "Merc DPS", "style": "danger"}
+          ],
+          "notes": [
+            {"text": "In T4 must spam enchants for re-spawned minions", "style": "secondary"}
+          ],
+          "links": []
+        }
+      ],
+      "Druid": [
+        {
+          "buildName": "Bear - Shockwave",
+          "tier": "Mid",
+          "roles": [
+            {"text": "DPS", "style": "danger"},
+            {"text": "CC", "style": "warning"}
+          ],
+          "notes": [],
+          "links": []
+        },
+        {
+          "buildName": "Wolf - Fury",
+          "tier": "Bad",
+          "roles": [
+            {"text": "DPS", "style": "danger"}
+          ],
+          "notes": [],
+          "links": []
+        },
+        {
+          "buildName": "Bear - Multiple Shot Maul (Demon Machine)",
+          "tier": "Bad",
+          "roles": [
+            {"text": "DPS", "style": "danger"}
+          ],
+          "notes": [],
+          "links": []
+        },
+        {
+          "buildName": "Summon",
+          "tier": "Good",
+          "roles": [
+            {"text": "Summon Wall", "style": "secondary"},
+            {"text": "DPS", "style": "danger"},
+            {"text": "HOW", "style": "success"}
+          ],
+          "notes": [
+            {"text": "Quezocoatl for speed", "style": "secondary"}
+          ],
+          "links": []
+        },
+        {
+          "buildName": "Summon (Oak & HOW)",
+          "tier": "Good",
+          "roles": [
+            {"text": "Summon Wall", "style": "secondary"},
+            {"text": "DPS", "style": "danger"},
+            {"text": "HOW", "style": "success"},
+            {"text": "OAK", "style": "success"}
+          ],
+          "notes": [
+            {"text": "Spirit Keeper", "style": "secondary"}
+          ],
+          "links": []
+        },
+        {
+          "buildName": "Summon (Bear)",
+          "tier": "Decent",
+          "roles": [
+            {"text": "Summon Wall", "style": "secondary"},
+            {"text": "HOW", "style": "success"}
+          ],
+          "notes": [
+            {"text": "Den Mother", "style": "secondary"}
+          ],
+          "links": []
+        },
+        {
+          "buildName": "Summon (Spirit Wolf)",
+          "tier": "Good",
+          "roles": [
+            {"text": "T4", "style": "dark"},
+            {"text": "Summon Wall", "style": "secondary"},
+            {"text": "DPS", "style": "danger"},
+            {"text": "HOW", "style": "success"}
+          ],
+          "notes": [],
+          "links": [
+            {"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=140&dexterity=0&vitality=295&energy=0&coupling=1&skills=00001001000100000000000000000000000000000011012020010020010020&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2Cnone%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm"}
+          ]
+        },
+        {
+          "buildName": "Spirits + Vines",
+          "tier": "Top",
+          "roles": [
+            {"text": "T4", "style": "dark"},
+            {"text": "OAK", "style": "success"},
+            {"text": "Worms", "style": "success"}
+          ],
+          "notes": [
+            {"text": "2 x Oak", "style": "secondary"}
+          ],
+          "links": [
+            {"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=96&difficulty=3&quests=1&strength=110&dexterity=10&vitality=370&energy=0&coupling=1&skills=00000000000000000000000001010001000000010001200120202000200100&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Spirit+Keeper%2C3%2Cnone%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm"}
+          ]
+        }
+      ],
+      "Assassin": [
+        {"buildName": "Blade Sentinel", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Stalkers cull(s) for speed", "style": "secondary"}], "links": []},
+        {"buildName": "Blade Fury", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Stone crusher & Twilight", "style": "secondary"}], "links": []},
+        {"buildName": "Summon Sin (Mindblast)", "tier": "Decent", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Dragon Tail (Fire Kick) Demon Machine", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "20 hard pts into Blade shield for more procs", "style": "secondary"}], "links": []},
+        {"buildName": "Dragon Tail (Fire Kick) Astreons", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Blade Fury (Demon Machine)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Summon Sin (Blade Sentinel)", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Summon casting isn't that good", "style": "secondary"}], "links": []},
+        {"buildName": "Physical Blade Dance (Chaos - Phys Dmg Focus)", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Poison Blade Dance (Chaos - Venom Dmg Focus)", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Must Item Swap pre-Buff", "style": "secondary"}], "links": []}
+      ],
+      "Barbarian": [
+        {"buildName": "Whirlwind (2-H)", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Must use 4 range adder weapon", "style": "secondary"}], "links": []},
+        {"buildName": "Whirlwind (Dual Wield)", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Deep wounds does not scale in party play", "style": "secondary"}], "links": []},
+        {"buildName": "Leap Attack (No shouts)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Eth Obedience starter weapon", "style": "secondary"}], "links": []},
+        {"buildName": "Double Throw (Physical)", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Deep wounds does not scale in party play", "style": "secondary"}], "links": []},
+        {"buildName": "Grimward + Big Shouts", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "Shouts", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=97&difficulty=3&quests=1&strength=86&dexterity=18&vitality=391&energy=0&coupling=1&skills=0100020100202020012000000000012001010000000000000000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wildspeaker%2C2%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Sandstorm+Trek%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Echoing+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Heart+Carver%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Heart+Carver%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]},
+        {"buildName": "Static Leap Attack 1H + Big Shouts", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "Shouts", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormlash%2C3%2C%2B+Sockets+Weapon%2C%2C%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=Twilight%27s+Reflection%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]},
+        {"buildName": "Static Leap Attack 1H + Twilight + Big Shouts", "tier": "Top", "roles": [{"text": "Shouts", "style": "success"}, {"text": "CC", "style": "warning"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormlash%2C3%2C%2B+Sockets+Weapon%2C%2C%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=Twilight%27s+Reflection%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]}
+      ],
+      "Amazon": [
+        {"buildName": "Fend", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Multiple Shot", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Multiple Shot (Demon Machine)", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Magic Arrow", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Damage scales from physical auras", "style": "secondary"}], "links": []},
+        {"buildName": "Pure Summon (Max Valk/Decoy Synergies)", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [], "links": [{"type": "planner", "label": "Starter Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000101010100200120201600010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Slow+Movement%29%2CDuskdeep%2CThe+Gladiator%27s+Bane%2CDemon+Machine%2CEcho+Quiver+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Sharp+Arrows%2CBloodfist%2CSandstorm+Trek%2CRazortail&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Athlete%27s+Diadem%2C3%2C%2B+Sockets+Helm%2C%2CUm+Rune%2CUm+Rune&armor=Peace+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Sandstorm+Trek%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Loyalty+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Inner_Sight-mercenary%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm"}]}
+      ],
+      "Necromancer": [
+        {"buildName": "Skele Summon + No innonce on merc", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}], "notes": [{"text": "Aggressive bloodwarps = more DPS", "style": "secondary"}], "links": []},
+        {"buildName": "Green Goblin (Demon Machine Merc + Skeles)", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}], "notes": [{"text": "Aggressive bloodwarps = more DPS", "style": "secondary"}], "links": []},
+        {"buildName": "Summoner - Pure Revive (Eternity & Sacred totem)", "tier": "Bad", "roles": [{"text": "Summon Wall", "style": "secondary"}], "notes": [], "links": []},
+        {"buildName": "Green Goblin + Skele snapshot + Curses", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}, {"text": "Curse", "style": "warning"}], "notes": [{"text": "High APM build", "style": "secondary"}, {"text": "Requires big worms for regen", "style": "secondary"}], "links": []},
+        {"buildName": "Dark Pact", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Curse", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Only Phys Curses", "tier": "Top", "roles": [{"text": "T4 only build", "style": "dark"}, {"text": "Curse", "style": "warning"}], "notes": [{"text": "Nec summons wont live in T4, low Psn res", "style": "secondary"}], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000012000010100000000000000000000000020000020000000200001000020&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Accursed+Diadem%2C3%2Cnone%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Sandstorm+Trek%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Accursed+Amulet%2C0%2Cnone%2C&ring1=The+Stone+of+Jordan%2C0%2Cnone&ring2=The+Stone+of+Jordan%2C0%2Cnone&weapon=Blackhand+Key%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Sacred+Totem%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm"}]}
+      ],
+      "Paladin": [
+        {"buildName": "Physical Zeal", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}], "notes": [], "links": []},
+        {"buildName": "Physical Sacrifice", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}], "notes": [{"text": "Avoid mobs you can't leech from", "style": "secondary"}], "links": []},
+        {"buildName": "Holy Nova + Aura holder", "tier": "Good", "roles": [{"text": "T4 only build", "style": "dark"}, {"text": "Healing", "style": "primary"}, {"text": "Aura", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=92&difficulty=3&quests=1&strength=58&dexterity=0&vitality=412&energy=0&coupling=1&skills=200000000000000000000100000101000000200001010101010101100101012020&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Steel+Shade%2C3%2Cnone%2C%2C%2C&armor=Guardian+Angel%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Titan%27s+Grip%2C3%2Cnone&boots=Sandstorm+Trek%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Marshal%27s+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring%2C0%2Cnone&ring2=Brilliant+Craft+Ring%2C0%2Cnone&weapon=Cloudcrack%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm"}]},
+        {"buildName": "Physical Charge (2-H)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=94&difficulty=3&quests=1&strength=76&dexterity=26&vitality=0&energy=0&coupling=1&skills=010001000000200000002000000101000000200000010000200000200000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Guillaume%27s+Face%2C2%2C%2B+Sockets+Helm%2CUm+Rune%2CUm+Rune%2CUm+Rune&armor=Wraithskin%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&gloves=Soul+Drainer%2C3%2Cnone&boots=Gore+Rider%2C2%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Highlord%27s+Wrath%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Death+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Colossus+Sword%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm"}]}
+      ]
+    }
+  },
+  "elemental": {
+    "title": "Elemental Focused P8 Mapping",
+    "descriptions": [
+      "Recommended to have a Druid Oak & Regen worm build. Recommended to have a Paladin with a res aura that matches the team element. Recommended to have a Static leap Barb for buffs and static.",
+      "BIG Conviction Paladin required.",
+      "Lower res from mercs is enough Necromancers are not needed. Sorceress is bad in party play because they already have high mastery from skills and do not benefit from party buffing as much.",
+      "Having all res auras from Paladins or/and Mercs for the aura's elemental mastery is crucial. Only review tooltip damage with all party buffs active!"
+    ],
+    "note": "NOTE! Must be tri-elemental damage across the team and have summons for T4. Necro summons are not advised, low Psn res and die fast.",
+    "classBuilds": {
+      "Sorceress": [
+        {"buildName": "Nova", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Hard to position in P8", "style": "secondary"}], "links": []},
+        {"buildName": "Charged Bolt", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Chain Lightning", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Frost Nova", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Hard to position in P8", "style": "secondary"}], "links": []},
+        {"buildName": "Frozen Orb", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Ice Barrage", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}, {"text": "CC", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Blizzard", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Damage area is unreliable", "style": "secondary"}], "links": []},
+        {"buildName": "Combustion", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Hard to position in P8", "style": "secondary"}], "links": []},
+        {"buildName": "Meteor", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Meteor delay holds this build back", "style": "secondary"}], "links": []},
+        {"buildName": "Hydra", "tier": "Mid", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Hydras double dip Res auras", "style": "secondary"}], "links": []},
+        {"buildName": "Dual Enchant", "tier": "Decent", "roles": [{"text": "T4", "style": "dark"}, {"text": "Enchant", "style": "success"}, {"text": "Merc DPS", "style": "danger"}], "notes": [{"text": "Pairs well with Fire & Cold arrow Zons", "style": "secondary"}], "links": []}
+      ],
+      "Druid": [
+        {"buildName": "Cold Elemental (Arctic Blast/Hurricane)", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Damage is strong but channel skills cant keep pace", "style": "secondary"}], "links": []},
+        {"buildName": "Fire Elemental", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}, {"text": "CC", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Wolf - Fire Claws", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "2 x Oak + Vines (Oak regen doubles if 2 are spawned)", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "OAK", "style": "success"}, {"text": "Worms", "style": "success"}], "notes": [{"text": "Required in all T4 groups", "style": "secondary"}, {"text": "Huge Team sustain", "style": "secondary"}], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=96&difficulty=3&quests=1&strength=110&dexterity=10&vitality=370&energy=0&coupling=1&skills=00000000000000000000000001010001000000010001200120202000200100&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Spirit+Keeper%2C3%2Cnone%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm"}]},
+        {"buildName": "Summon (Raven)", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}, {"text": "OAK", "style": "success"}], "notes": [{"text": "Eaglehorn", "style": "secondary"}], "links": []},
+        {"buildName": "Poison Creeper (Worm Re-Summoning)", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Worms", "style": "success"}], "notes": [{"text": "Psn scaling bad in groups", "style": "secondary"}, {"text": "Sustainr worms", "style": "secondary"}], "links": []}
+      ],
+      "Assassin": [
+        {"buildName": "Chain Lightning Sentry", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Traps cant keep group pace", "style": "secondary"}], "links": []},
+        {"buildName": "Wake of Fire", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Traps cant keep group pace", "style": "secondary"}], "links": []},
+        {"buildName": "Summon Sin (MA Skills)", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}], "notes": [{"text": "Whispering Mirage + Nats set for budget", "style": "secondary"}], "links": []},
+        {"buildName": "Summon Sin (Elemental trap)", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}], "notes": [{"text": "Whispering Mirage + Nats set for budget", "style": "secondary"}], "links": []},
+        {"buildName": "Phoenix Strike", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Full nats for budget", "style": "secondary"}], "links": []},
+        {"buildName": "Dragon Tail (Fire Kick) Astreons", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [], "links": []}
+      ],
+      "Barbarian": [
+        {"buildName": "Fire Whirlwind (2x Flamebellow)", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Ele Proc Leap Attack", "tier": "Decent", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Destruction / Stormspire / Rapture + Innocence + % Large Charms", "style": "secondary"}], "links": []},
+        {"buildName": "Static Leap Attack 2H + Big Shouts", "tier": "Top", "roles": [{"text": "Shouts", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormspire%2C3%2C%2B+Sockets+Weapon%2CAmn+Rune%2CAmn+Rune%2CHel+Rune%2CHel+Rune%2CAmn+Rune%2CHel+Rune&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}, {"type": "planner", "label": "T4 Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Halaberd%27s+Reign%2C3%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Sandstorm+Trek%2C3%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormspire%2C3%2C%2B+Sockets+Weapon%2CHel+Rune%2CHel+Rune%2CHel+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]},
+        {"buildName": "Static Leap Attack 1H + Big Shouts", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "Shouts", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormlash%2C3%2C%2B+Sockets+Weapon%2C%2C%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=Twilight%27s+Reflection%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]},
+        {"buildName": "Static Leap Attack 1H + Twilight + Big Shouts", "tier": "Top", "roles": [{"text": "Shouts", "style": "success"}, {"text": "CC", "style": "warning"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormlash%2C3%2C%2B+Sockets+Weapon%2C%2C%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=Twilight%27s+Reflection%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]}
+      ],
+      "Amazon": [
+        {"buildName": "Lightning Fury", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Lightning Strike", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Power Strike", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Plague Javelin", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Psn scaling bad in groups", "style": "secondary"}], "links": []},
+        {"buildName": "Freezing Arrow", "tier": "Decent", "roles": [{"text": "CC", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Cold Arrow", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Fire Arrow", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Explosive Arrow", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []}
+      ],
+      "Necromancer": [
+        {"buildName": "Poison Nova / Desecrate", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Curse", "style": "warning"}], "notes": [{"text": "Psn scaling bad in groups", "style": "secondary"}], "links": []},
+        {"buildName": "Poison Strike", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Psn scaling bad in groups", "style": "secondary"}], "links": []},
+        {"buildName": "Corpse Explosion", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Damage is based off base mob hp not actual", "style": "secondary"}], "links": []},
+        {"buildName": "Elemental Summoner (Mage Skeles + Ele Revives)", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Ele Skeleton scaling bad in groups", "style": "secondary"}], "links": []},
+        {"buildName": "Fire Golems", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Curse Nec", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "Curse", "style": "warning"}], "notes": [], "links": []}
+      ],
+      "Paladin": [
+        {"buildName": "Holy Nova + Aura (Big Res aura/Conviction)", "tier": "Decent", "roles": [{"text": "Healing", "style": "primary"}, {"text": "Aura", "style": "success"}], "notes": [{"text": "Use Skillers & Gear for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Holy Nova + Aura (Big Res aura/Conviction)", "tier": "Top", "roles": [{"text": "T4 Only", "style": "dark"}, {"text": "Healing", "style": "primary"}, {"text": "Aura", "style": "success"}], "notes": [{"text": "Use Skillers & Gear for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Vengeance 2H Zenith", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "Aura", "style": "success"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Conviction", "style": "secondary"}, {"text": "Use Skillers for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Vengeance", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "Aura", "style": "success"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Conviction", "style": "secondary"}, {"text": "Use Skillers for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Sacrifice Ele Paladin", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}, {"text": "CC", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Holy Elemental Auras - Charge (Native Aura)", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Starter till Auradin gear is acquired", "style": "secondary"}], "links": []},
+        {"buildName": "Holy Freeze - Charge (Doom + Shattered Wall)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}, {"text": "CC", "style": "warning"}], "notes": [{"text": "Use Skillers for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Holy Fire - Charge (HOJ + 2x Dragon)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}], "notes": [{"text": "Use Skillers for Party Aura", "style": "secondary"}], "links": []}
+      ]
+    }
+  }
+}
+;

--- a/group-data.json
+++ b/group-data.json
@@ -1,0 +1,401 @@
+{
+  "season": 13,
+  "updatedDate": "March 23rd 2026",
+  "bannerText": "Currently, this is just a copy from Season 12",
+  "generalists": {
+    "title": "Public Map Focused P8 Mapping",
+    "descriptions": [
+      "Early season public map games tend to lean Elemental. Late season giga-physical builds show up.",
+      "The following builds can play well with and/or buff both Physical or Elemental teams.",
+      "Summon builds perform well in public games because of the safety wall they provide."
+    ],
+    "note": "NOTE! This is not Tiered or ordered, and some builds can shine in physical more than elemental and vice versa.",
+    "builds": [
+      {
+        "buildName": "Summons",
+        "className": "Druid",
+        "tableClass": "table-druid",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Summon Wall", "style": "secondary"},
+          {"text": "HOW", "style": "success"}
+        ],
+        "notes": [
+          {"text": "Raven - Eaglehorn", "style": "secondary"},
+          {"text": "Bear - Den Mother", "style": "secondary"},
+          {"text": "Wolf - Fenris", "style": "secondary"}
+        ]
+      },
+      {
+        "buildName": "Spirits + Vines",
+        "className": "Druid",
+        "tableClass": "table-druid",
+        "roles": [
+          {"text": "HOW", "style": "success"},
+          {"text": "OAK", "style": "success"},
+          {"text": "Worms", "style": "success"}
+        ],
+        "notes": [
+          {"text": "Z-DPS", "style": "secondary", "pill": false},
+          {"text": "Spirit Keeper", "style": "secondary", "pill": false},
+          {"text": "2 x Oak for Elemental Groups", "style": "secondary", "pill": false},
+          {"text": "Huge Party Sustain", "style": "secondary", "pill": false}
+        ]
+      },
+      {
+        "buildName": "Phoenix Strike",
+        "className": "Assassin",
+        "tableClass": "table-assassin",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Tail (Fire Kick) Astreons",
+        "className": "Assassin",
+        "tableClass": "table-assassin",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Static Leap Attack + Big Shouts",
+        "className": "Barbarian",
+        "tableClass": "table-barbarian",
+        "roles": [
+          {"text": "CC", "style": "warning"}
+        ],
+        "notes": [
+          {"text": "Stormlash or Schafers + Twlight + Ttians grip + Cyclopean + Gorefoot", "style": "secondary", "pill": false}
+        ]
+      },
+      {
+        "buildName": "Whirlwind + Shouts",
+        "className": "Barbarian",
+        "tableClass": "table-barbarian",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": [
+          {"text": "Static Proc", "style": "secondary", "pill": false}
+        ]
+      },
+      {
+        "buildName": "Decoy & Valks",
+        "className": "Amazon",
+        "tableClass": "table-amazon",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Summon Wall", "style": "secondary"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Multi Shot",
+        "className": "Amazon",
+        "tableClass": "table-amazon",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Strafe",
+        "className": "Amazon",
+        "tableClass": "table-amazon",
+        "roles": [
+          {"text": "DPS", "style": "danger"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Hybrid Curse + Summons",
+        "className": "Necromancer",
+        "tableClass": "table-necro",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Summon Wall", "style": "secondary"},
+          {"text": "Curse", "style": "warning"}
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Giga Curse",
+        "className": "Necromancer",
+        "tableClass": "table-necro",
+        "roles": [
+          {"text": "Curse", "style": "warning"}
+        ],
+        "notes": [
+          {"text": "Z-DPS", "style": "secondary", "pill": false}
+        ]
+      },
+      {
+        "buildName": "Vengeance",
+        "className": "Paladin",
+        "tableClass": "table-paladin",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Aura", "style": "success"}
+        ],
+        "notes": [
+          {"text": "Conviction", "style": "secondary"}
+        ]
+      },
+      {
+        "buildName": "Holy Fire - Charge (HOJ + 2x Dragon)",
+        "className": "Paladin",
+        "tableClass": "table-paladin",
+        "roles": [
+          {"text": "DPS", "style": "danger"},
+          {"text": "Aura", "style": "success"}
+        ],
+        "notes": [
+          {"text": "Conviction", "style": "secondary"}
+        ]
+      }
+    ]
+  },
+  "physical": {
+    "title": "Physical Focused P8 Mapping",
+    "descriptions": [
+      "Recommended to have a Buff Barbarian. Recommended to get all Physical auras via Paladin or Mercenary. Recommended all necros to be Curse hybrid. All spare mercs should be A1 Physical Demonmachine.",
+      "Scaling deadly strike is crucial. Only review tooltip damage with all party buffs active!"
+    ],
+    "note": "NOTE! Must have summons for T4. Necro summons are not advised, low Psn res and die fast.",
+    "classBuilds": {
+      "Sorceress": [
+        {
+          "buildName": "Dual Enchant & A1 Innocence Demonmachine",
+          "tier": "Good",
+          "roles": [
+            {"text": "T4", "style": "dark"},
+            {"text": "Enchant", "style": "success"},
+            {"text": "Merc DPS", "style": "danger"}
+          ],
+          "notes": [
+            {"text": "In T4 must spam enchants for re-spawned minions", "style": "secondary"}
+          ],
+          "links": []
+        }
+      ],
+      "Druid": [
+        {
+          "buildName": "Bear - Shockwave",
+          "tier": "Mid",
+          "roles": [
+            {"text": "DPS", "style": "danger"},
+            {"text": "CC", "style": "warning"}
+          ],
+          "notes": [],
+          "links": []
+        },
+        {
+          "buildName": "Wolf - Fury",
+          "tier": "Bad",
+          "roles": [
+            {"text": "DPS", "style": "danger"}
+          ],
+          "notes": [],
+          "links": []
+        },
+        {
+          "buildName": "Bear - Multiple Shot Maul (Demon Machine)",
+          "tier": "Bad",
+          "roles": [
+            {"text": "DPS", "style": "danger"}
+          ],
+          "notes": [],
+          "links": []
+        },
+        {
+          "buildName": "Summon",
+          "tier": "Good",
+          "roles": [
+            {"text": "Summon Wall", "style": "secondary"},
+            {"text": "DPS", "style": "danger"},
+            {"text": "HOW", "style": "success"}
+          ],
+          "notes": [
+            {"text": "Quezocoatl for speed", "style": "secondary"}
+          ],
+          "links": []
+        },
+        {
+          "buildName": "Summon (Oak & HOW)",
+          "tier": "Good",
+          "roles": [
+            {"text": "Summon Wall", "style": "secondary"},
+            {"text": "DPS", "style": "danger"},
+            {"text": "HOW", "style": "success"},
+            {"text": "OAK", "style": "success"}
+          ],
+          "notes": [
+            {"text": "Spirit Keeper", "style": "secondary"}
+          ],
+          "links": []
+        },
+        {
+          "buildName": "Summon (Bear)",
+          "tier": "Decent",
+          "roles": [
+            {"text": "Summon Wall", "style": "secondary"},
+            {"text": "HOW", "style": "success"}
+          ],
+          "notes": [
+            {"text": "Den Mother", "style": "secondary"}
+          ],
+          "links": []
+        },
+        {
+          "buildName": "Summon (Spirit Wolf)",
+          "tier": "Good",
+          "roles": [
+            {"text": "T4", "style": "dark"},
+            {"text": "Summon Wall", "style": "secondary"},
+            {"text": "DPS", "style": "danger"},
+            {"text": "HOW", "style": "success"}
+          ],
+          "notes": [],
+          "links": [
+            {"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=140&dexterity=0&vitality=295&energy=0&coupling=1&skills=00001001000100000000000000000000000000000011012020010020010020&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2Cnone%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm"}
+          ]
+        },
+        {
+          "buildName": "Spirits + Vines",
+          "tier": "Top",
+          "roles": [
+            {"text": "T4", "style": "dark"},
+            {"text": "OAK", "style": "success"},
+            {"text": "Worms", "style": "success"}
+          ],
+          "notes": [
+            {"text": "2 x Oak", "style": "secondary"}
+          ],
+          "links": [
+            {"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=96&difficulty=3&quests=1&strength=110&dexterity=10&vitality=370&energy=0&coupling=1&skills=00000000000000000000000001010001000000010001200120202000200100&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Spirit+Keeper%2C3%2Cnone%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm"}
+          ]
+        }
+      ],
+      "Assassin": [
+        {"buildName": "Blade Sentinel", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Stalkers cull(s) for speed", "style": "secondary"}], "links": []},
+        {"buildName": "Blade Fury", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Stone crusher & Twilight", "style": "secondary"}], "links": []},
+        {"buildName": "Summon Sin (Mindblast)", "tier": "Decent", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Dragon Tail (Fire Kick) Demon Machine", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "20 hard pts into Blade shield for more procs", "style": "secondary"}], "links": []},
+        {"buildName": "Dragon Tail (Fire Kick) Astreons", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Blade Fury (Demon Machine)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Summon Sin (Blade Sentinel)", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Summon casting isn't that good", "style": "secondary"}], "links": []},
+        {"buildName": "Physical Blade Dance (Chaos - Phys Dmg Focus)", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Poison Blade Dance (Chaos - Venom Dmg Focus)", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Must Item Swap pre-Buff", "style": "secondary"}], "links": []}
+      ],
+      "Barbarian": [
+        {"buildName": "Whirlwind (2-H)", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Must use 4 range adder weapon", "style": "secondary"}], "links": []},
+        {"buildName": "Whirlwind (Dual Wield)", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Deep wounds does not scale in party play", "style": "secondary"}], "links": []},
+        {"buildName": "Leap Attack (No shouts)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Eth Obedience starter weapon", "style": "secondary"}], "links": []},
+        {"buildName": "Double Throw (Physical)", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Deep wounds does not scale in party play", "style": "secondary"}], "links": []},
+        {"buildName": "Grimward + Big Shouts", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "Shouts", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=97&difficulty=3&quests=1&strength=86&dexterity=18&vitality=391&energy=0&coupling=1&skills=0100020100202020012000000000012001010000000000000000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wildspeaker%2C2%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Sandstorm+Trek%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Echoing+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Heart+Carver%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Heart+Carver%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]},
+        {"buildName": "Static Leap Attack 1H + Big Shouts", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "Shouts", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormlash%2C3%2C%2B+Sockets+Weapon%2C%2C%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=Twilight%27s+Reflection%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]},
+        {"buildName": "Static Leap Attack 1H + Twilight + Big Shouts", "tier": "Top", "roles": [{"text": "Shouts", "style": "success"}, {"text": "CC", "style": "warning"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormlash%2C3%2C%2B+Sockets+Weapon%2C%2C%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=Twilight%27s+Reflection%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]}
+      ],
+      "Amazon": [
+        {"buildName": "Fend", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Multiple Shot", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Multiple Shot (Demon Machine)", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Magic Arrow", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Damage scales from physical auras", "style": "secondary"}], "links": []},
+        {"buildName": "Pure Summon (Max Valk/Decoy Synergies)", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [], "links": [{"type": "planner", "label": "Starter Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000101010100200120201600010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Slow+Movement%29%2CDuskdeep%2CThe+Gladiator%27s+Bane%2CDemon+Machine%2CEcho+Quiver+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Sharp+Arrows%2CBloodfist%2CSandstorm+Trek%2CRazortail&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Athlete%27s+Diadem%2C3%2C%2B+Sockets+Helm%2C%2CUm+Rune%2CUm+Rune&armor=Peace+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Sandstorm+Trek%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Loyalty+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Inner_Sight-mercenary%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm"}]}
+      ],
+      "Necromancer": [
+        {"buildName": "Skele Summon + No innonce on merc", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}], "notes": [{"text": "Aggressive bloodwarps = more DPS", "style": "secondary"}], "links": []},
+        {"buildName": "Green Goblin (Demon Machine Merc + Skeles)", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}], "notes": [{"text": "Aggressive bloodwarps = more DPS", "style": "secondary"}], "links": []},
+        {"buildName": "Summoner - Pure Revive (Eternity & Sacred totem)", "tier": "Bad", "roles": [{"text": "Summon Wall", "style": "secondary"}], "notes": [], "links": []},
+        {"buildName": "Green Goblin + Skele snapshot + Curses", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}, {"text": "Curse", "style": "warning"}], "notes": [{"text": "High APM build", "style": "secondary"}, {"text": "Requires big worms for regen", "style": "secondary"}], "links": []},
+        {"buildName": "Dark Pact", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Curse", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Only Phys Curses", "tier": "Top", "roles": [{"text": "T4 only build", "style": "dark"}, {"text": "Curse", "style": "warning"}], "notes": [{"text": "Nec summons wont live in T4, low Psn res", "style": "secondary"}], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000012000010100000000000000000000000020000020000000200001000020&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Accursed+Diadem%2C3%2Cnone%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Sandstorm+Trek%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Accursed+Amulet%2C0%2Cnone%2C&ring1=The+Stone+of+Jordan%2C0%2Cnone&ring2=The+Stone+of+Jordan%2C0%2Cnone&weapon=Blackhand+Key%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Sacred+Totem%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm&charm=%2B1+Hexing+Grand+Charm"}]}
+      ],
+      "Paladin": [
+        {"buildName": "Physical Zeal", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}], "notes": [], "links": []},
+        {"buildName": "Physical Sacrifice", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}], "notes": [{"text": "Avoid mobs you can't leech from", "style": "secondary"}], "links": []},
+        {"buildName": "Holy Nova + Aura holder", "tier": "Good", "roles": [{"text": "T4 only build", "style": "dark"}, {"text": "Healing", "style": "primary"}, {"text": "Aura", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=92&difficulty=3&quests=1&strength=58&dexterity=0&vitality=412&energy=0&coupling=1&skills=200000000000000000000100000101000000200001010101010101100101012020&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Steel+Shade%2C3%2Cnone%2C%2C%2C&armor=Guardian+Angel%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Titan%27s+Grip%2C3%2Cnone&boots=Sandstorm+Trek%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Marshal%27s+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring%2C0%2Cnone&ring2=Brilliant+Craft+Ring%2C0%2Cnone&weapon=Cloudcrack%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm"}]},
+        {"buildName": "Physical Charge (2-H)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=94&difficulty=3&quests=1&strength=76&dexterity=26&vitality=0&energy=0&coupling=1&skills=010001000000200000002000000101000000200000010000200000200000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Guillaume%27s+Face%2C2%2C%2B+Sockets+Helm%2CUm+Rune%2CUm+Rune%2CUm+Rune&armor=Wraithskin%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&gloves=Soul+Drainer%2C3%2Cnone&boots=Gore+Rider%2C2%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Highlord%27s+Wrath%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Death+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Colossus+Sword%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Captain%27s+Grand+Charm"}]}
+      ]
+    }
+  },
+  "elemental": {
+    "title": "Elemental Focused P8 Mapping",
+    "descriptions": [
+      "Recommended to have a Druid Oak & Regen worm build. Recommended to have a Paladin with a res aura that matches the team element. Recommended to have a Static leap Barb for buffs and static.",
+      "BIG Conviction Paladin required.",
+      "Lower res from mercs is enough Necromancers are not needed. Sorceress is bad in party play because they already have high mastery from skills and do not benefit from party buffing as much.",
+      "Having all res auras from Paladins or/and Mercs for the aura's elemental mastery is crucial. Only review tooltip damage with all party buffs active!"
+    ],
+    "note": "NOTE! Must be tri-elemental damage across the team and have summons for T4. Necro summons are not advised, low Psn res and die fast.",
+    "classBuilds": {
+      "Sorceress": [
+        {"buildName": "Nova", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Hard to position in P8", "style": "secondary"}], "links": []},
+        {"buildName": "Charged Bolt", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Chain Lightning", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Frost Nova", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Hard to position in P8", "style": "secondary"}], "links": []},
+        {"buildName": "Frozen Orb", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Ice Barrage", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}, {"text": "CC", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Blizzard", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Damage area is unreliable", "style": "secondary"}], "links": []},
+        {"buildName": "Combustion", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Hard to position in P8", "style": "secondary"}], "links": []},
+        {"buildName": "Meteor", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Meteor delay holds this build back", "style": "secondary"}], "links": []},
+        {"buildName": "Hydra", "tier": "Mid", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Hydras double dip Res auras", "style": "secondary"}], "links": []},
+        {"buildName": "Dual Enchant", "tier": "Decent", "roles": [{"text": "T4", "style": "dark"}, {"text": "Enchant", "style": "success"}, {"text": "Merc DPS", "style": "danger"}], "notes": [{"text": "Pairs well with Fire & Cold arrow Zons", "style": "secondary"}], "links": []}
+      ],
+      "Druid": [
+        {"buildName": "Cold Elemental (Arctic Blast/Hurricane)", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Damage is strong but channel skills cant keep pace", "style": "secondary"}], "links": []},
+        {"buildName": "Fire Elemental", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}, {"text": "CC", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Wolf - Fire Claws", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "2 x Oak + Vines (Oak regen doubles if 2 are spawned)", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "OAK", "style": "success"}, {"text": "Worms", "style": "success"}], "notes": [{"text": "Required in all T4 groups", "style": "secondary"}, {"text": "Huge Team sustain", "style": "secondary"}], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=96&difficulty=3&quests=1&strength=110&dexterity=10&vitality=370&energy=0&coupling=1&skills=00000000000000000000000001010001000000010001200120202000200100&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Spirit+Keeper%2C3%2Cnone%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm"}]},
+        {"buildName": "Summon (Raven)", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}, {"text": "OAK", "style": "success"}], "notes": [{"text": "Eaglehorn", "style": "secondary"}], "links": []},
+        {"buildName": "Poison Creeper (Worm Re-Summoning)", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Worms", "style": "success"}], "notes": [{"text": "Psn scaling bad in groups", "style": "secondary"}, {"text": "Sustainr worms", "style": "secondary"}], "links": []}
+      ],
+      "Assassin": [
+        {"buildName": "Chain Lightning Sentry", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Traps cant keep group pace", "style": "secondary"}], "links": []},
+        {"buildName": "Wake of Fire", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Traps cant keep group pace", "style": "secondary"}], "links": []},
+        {"buildName": "Summon Sin (MA Skills)", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}], "notes": [{"text": "Whispering Mirage + Nats set for budget", "style": "secondary"}], "links": []},
+        {"buildName": "Summon Sin (Elemental trap)", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}, {"text": "Summon Wall", "style": "secondary"}], "notes": [{"text": "Whispering Mirage + Nats set for budget", "style": "secondary"}], "links": []},
+        {"buildName": "Phoenix Strike", "tier": "Top", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Full nats for budget", "style": "secondary"}], "links": []},
+        {"buildName": "Dragon Tail (Fire Kick) Astreons", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [], "links": []}
+      ],
+      "Barbarian": [
+        {"buildName": "Fire Whirlwind (2x Flamebellow)", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Ele Proc Leap Attack", "tier": "Decent", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Destruction / Stormspire / Rapture + Innocence + % Large Charms", "style": "secondary"}], "links": []},
+        {"buildName": "Static Leap Attack 2H + Big Shouts", "tier": "Top", "roles": [{"text": "Shouts", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormspire%2C3%2C%2B+Sockets+Weapon%2CAmn+Rune%2CAmn+Rune%2CHel+Rune%2CHel+Rune%2CAmn+Rune%2CHel+Rune&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}, {"type": "planner", "label": "T4 Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Halaberd%27s+Reign%2C3%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Sandstorm+Trek%2C3%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormspire%2C3%2C%2B+Sockets+Weapon%2CHel+Rune%2CHel+Rune%2CHel+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]},
+        {"buildName": "Static Leap Attack 1H + Big Shouts", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "Shouts", "style": "success"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormlash%2C3%2C%2B+Sockets+Weapon%2C%2C%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=Twilight%27s+Reflection%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]},
+        {"buildName": "Static Leap Attack 1H + Twilight + Big Shouts", "tier": "Top", "roles": [{"text": "Shouts", "style": "success"}, {"text": "CC", "style": "warning"}], "notes": [], "links": [{"type": "planner", "label": "Build Planner", "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=66&dexterity=110&vitality=329&energy=0&coupling=1&skills=0100000100002000002020000000012001010001000101000120000001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CHeavenly+Garb%2CPurity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cyclopean+Roar%2C2%2C%2B+Max+Poison+Resist%2C%2CUm+Rune%2CUm+Rune&armor=Leviathan%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C%2C%2CHel+Rune%2CHel+Rune&gloves=Titan%27s+Grip%2C3%2C%2B+ICB&boots=Gorefoot%2C1%2C%2B+Max+Lightning+Resist&belt=String+of+Ears%2C2%2C%2B+Max+Resist%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+Max+Resist%2C&ring1=Raven+Frost%2C0%2C%2B+Attack+Rating&ring2=Dwarf+Star%2C0%2C%2B+Attack+Rating&weapon=Stormlash%2C3%2C%2B+Sockets+Weapon%2C%2C%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune%2CAmn+Rune&offhand=Twilight%27s+Reflection%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Prayer-mercenary_weapon%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm&charm=%2B1+Sounding+Grand+Charm"}]}
+      ],
+      "Amazon": [
+        {"buildName": "Lightning Fury", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Lightning Strike", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Power Strike", "tier": "Decent", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Plague Javelin", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Psn scaling bad in groups", "style": "secondary"}], "links": []},
+        {"buildName": "Freezing Arrow", "tier": "Decent", "roles": [{"text": "CC", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Cold Arrow", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Fire Arrow", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []},
+        {"buildName": "Explosive Arrow", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Res auras scale damage a lot", "style": "secondary"}], "links": []}
+      ],
+      "Necromancer": [
+        {"buildName": "Poison Nova / Desecrate", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Curse", "style": "warning"}], "notes": [{"text": "Psn scaling bad in groups", "style": "secondary"}], "links": []},
+        {"buildName": "Poison Strike", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Psn scaling bad in groups", "style": "secondary"}], "links": []},
+        {"buildName": "Corpse Explosion", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Damage is based off base mob hp not actual", "style": "secondary"}], "links": []},
+        {"buildName": "Elemental Summoner (Mage Skeles + Ele Revives)", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Ele Skeleton scaling bad in groups", "style": "secondary"}], "links": []},
+        {"buildName": "Fire Golems", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "DPS", "style": "danger"}], "notes": [], "links": []},
+        {"buildName": "Curse Nec", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "Curse", "style": "warning"}], "notes": [], "links": []}
+      ],
+      "Paladin": [
+        {"buildName": "Holy Nova + Aura (Big Res aura/Conviction)", "tier": "Decent", "roles": [{"text": "Healing", "style": "primary"}, {"text": "Aura", "style": "success"}], "notes": [{"text": "Use Skillers & Gear for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Holy Nova + Aura (Big Res aura/Conviction)", "tier": "Top", "roles": [{"text": "T4 Only", "style": "dark"}, {"text": "Healing", "style": "primary"}, {"text": "Aura", "style": "success"}], "notes": [{"text": "Use Skillers & Gear for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Vengeance 2H Zenith", "tier": "Good", "roles": [{"text": "T4", "style": "dark"}, {"text": "Aura", "style": "success"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Conviction", "style": "secondary"}, {"text": "Use Skillers for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Vengeance", "tier": "Top", "roles": [{"text": "T4", "style": "dark"}, {"text": "Aura", "style": "success"}, {"text": "DPS", "style": "danger"}], "notes": [{"text": "Conviction", "style": "secondary"}, {"text": "Use Skillers for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Sacrifice Ele Paladin", "tier": "Mid", "roles": [{"text": "DPS", "style": "danger"}, {"text": "CC", "style": "warning"}], "notes": [], "links": []},
+        {"buildName": "Holy Elemental Auras - Charge (Native Aura)", "tier": "Bad", "roles": [{"text": "DPS", "style": "danger"}], "notes": [{"text": "Starter till Auradin gear is acquired", "style": "secondary"}], "links": []},
+        {"buildName": "Holy Freeze - Charge (Doom + Shattered Wall)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}, {"text": "CC", "style": "warning"}], "notes": [{"text": "Use Skillers for Party Aura", "style": "secondary"}], "links": []},
+        {"buildName": "Holy Fire - Charge (HOJ + 2x Dragon)", "tier": "Good", "roles": [{"text": "DPS", "style": "danger"}, {"text": "Aura", "style": "success"}], "notes": [{"text": "Use Skillers for Party Aura", "style": "secondary"}], "links": []}
+      ]
+    }
+  }
+}

--- a/group.html
+++ b/group.html
@@ -881,10 +881,40 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 			</div>
 		</div>
 
+		<div class="col-sm-6 col-md-3 col-xl-auto d-flex align-items-center">
+			<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127922; Spin the Wheel</button>
+		</div>
+
+	</div>
+</div>
+
+<!-- Wheel Modal -->
+<div class="modal fade" id="wheelModal" tabindex="-1" aria-labelledby="wheelModalLabel" aria-hidden="true">
+	<div class="modal-dialog modal-dialog-centered modal-lg">
+		<div class="modal-content bg-dark text-white">
+			<div class="modal-header border-secondary">
+				<h5 class="modal-title" id="wheelModalLabel">&#127922; Spin the Wheel</h5>
+				<button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<div class="modal-body text-center p-2">
+				<div style="position:relative;display:inline-block;">
+					<canvas id="wheelCanvas" width="500" height="500"></canvas>
+					<div style="position:absolute;top:10px;left:50%;transform:translateX(-50%);font-size:32px;line-height:1;filter:drop-shadow(0 2px 4px rgba(0,0,0,.6));">&#9660;</div>
+				</div>
+				<div class="mt-2">
+					<button class="btn btn-primary btn-lg px-5" id="spinBtn" onclick="spinWheel()">SPIN</button>
+				</div>
+				<div id="wheelResult" class="mt-3 fs-3 fw-bold" style="min-height:2.5rem;"></div>
+			</div>
+		</div>
 	</div>
 </div>
 
 <div id="generalists" style="display: none;">
+
+	<div class="text-center my-2">
+		<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127922; Spin the Wheel</button>
+	</div>
 
 	<div class="alert alert-dark" role="alert">
 		<h2>Public Map Focused P8 Mapping</h2>
@@ -2822,6 +2852,182 @@ const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstra
 			}
 		});
 	}
+</script>
+<script>
+// ── Wheel of Names ──
+var wheelClassColors = {
+  'Sorceress':'#4a86c8','Druid':'#5a9e6f','Assassin':'#d4944a',
+  'Barbarian':'#c45a5a','Amazon':'#4abcd4','Necromancer':'#9a7ec0','Paladin':'#c9b44a'
+};
+var wheelEntries = [], wheelAngle = 0, wheelSpinning = false, wheelAnimId = null;
+
+function getVisibleBuilds() {
+  var builds = [];
+  var selectedRadio = document.querySelector('input[name="groupType"]:checked');
+  if (!selectedRadio) return builds;
+  var groupType = selectedRadio.value;
+
+  if (groupType === 'groupType1') {
+    // Generalists: rows are <tr class="table-druid"> etc. inside #generalists table
+    var genTable = document.querySelector('#generalists table');
+    if (genTable) {
+      var rows = genTable.querySelectorAll('tr[class^="table-"]');
+      rows.forEach(function(row) {
+        var cells = row.querySelectorAll('td');
+        if (cells.length >= 2) {
+          var buildName = cells[0].textContent.trim();
+          var classBadge = cells[1].textContent.trim();
+          builds.push({ name: classBadge + ' - ' + buildName, buildName: buildName, className: classBadge });
+        }
+      });
+    }
+  } else {
+    // Physical or Elemental: rows inside class tbodies
+    var containerId = groupType === 'groupType2' ? 'physical' : 'elemental';
+    var suffix = groupType === 'groupType2' ? '' : '2';
+    var classNames = ['Sorceress','Druid','Assassin','Barbarian','Amazon','Necromancer','Paladin'];
+    classNames.forEach(function(cls) {
+      var cb = document.getElementById('checkbox' + cls);
+      if (!cb || !cb.checked) return;
+      var tbody = document.getElementById('tbody' + cls + suffix);
+      if (!tbody || tbody.style.display === 'none') return;
+      var rows = tbody.querySelectorAll('tr');
+      rows.forEach(function(row) {
+        var cells = row.querySelectorAll('td');
+        if (cells.length >= 1) {
+          var buildName = cells[0].textContent.trim();
+          if (buildName) builds.push({ name: cls + ' - ' + buildName, buildName: buildName, className: cls });
+        }
+      });
+    });
+  }
+  return builds;
+}
+
+function escapeHtml(text) { var d = document.createElement('div'); d.textContent = text; return d.innerHTML; }
+
+function shadeColor(hex, percent) {
+  var num = parseInt(hex.replace('#',''), 16);
+  var r = Math.min(255, Math.max(0, (num >> 16) + percent));
+  var g = Math.min(255, Math.max(0, ((num >> 8) & 0xff) + percent));
+  var b = Math.min(255, Math.max(0, (num & 0xff) + percent));
+  return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+}
+
+function drawWheel() {
+  var canvas = document.getElementById('wheelCanvas');
+  if (!canvas) return;
+  var ctx = canvas.getContext('2d');
+  var cx = canvas.width / 2, cy = canvas.height / 2, r = Math.min(cx, cy) - 15;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  if (wheelEntries.length === 0) {
+    ctx.fillStyle = '#333'; ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = '#aaa'; ctx.font = '20px sans-serif'; ctx.textAlign = 'center';
+    ctx.fillText('No builds visible', cx, cy);
+    return;
+  }
+  var n = wheelEntries.length;
+  var sliceAngle = (Math.PI * 2) / n;
+  for (var i = 0; i < n; i++) {
+    var start = wheelAngle + i * sliceAngle;
+    var end = start + sliceAngle;
+    var baseColor = wheelClassColors[wheelEntries[i].className] || '#666';
+    ctx.fillStyle = i % 2 === 0 ? baseColor : shadeColor(baseColor, -25);
+    ctx.beginPath(); ctx.moveTo(cx, cy); ctx.arc(cx, cy, r, start, end); ctx.closePath(); ctx.fill();
+    ctx.strokeStyle = '#1a1a1a'; ctx.lineWidth = 1.5; ctx.stroke();
+    ctx.save(); ctx.translate(cx, cy); ctx.rotate(start + sliceAngle / 2);
+    ctx.fillStyle = '#fff'; ctx.shadowColor = 'rgba(0,0,0,0.7)'; ctx.shadowBlur = 3;
+    var fontSize = n > 40 ? 8 : n > 25 ? 10 : n > 15 ? 12 : 14;
+    ctx.font = 'bold ' + fontSize + 'px sans-serif'; ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+    var label = wheelEntries[i].buildName;
+    var maxLen = n > 30 ? 20 : 30;
+    if (label.length > maxLen) label = label.substring(0, maxLen - 1) + '\u2026';
+    ctx.fillText(label, r - 10, 0);
+    ctx.restore();
+  }
+  ctx.beginPath(); ctx.arc(cx, cy, 22, 0, Math.PI * 2);
+  ctx.fillStyle = '#1a1a1a'; ctx.fill(); ctx.strokeStyle = '#555'; ctx.lineWidth = 2; ctx.stroke();
+}
+
+function openWheelModal() {
+  wheelEntries = getVisibleBuilds();
+  wheelAngle = 0; wheelSpinning = false;
+  if (wheelAnimId) { cancelAnimationFrame(wheelAnimId); wheelAnimId = null; }
+  document.getElementById('wheelResult').textContent = '';
+  document.getElementById('spinBtn').disabled = false;
+  drawWheel();
+  var modal = new bootstrap.Modal(document.getElementById('wheelModal'));
+  modal.show();
+}
+
+function spinWheel() {
+  if (wheelSpinning || wheelEntries.length === 0) return;
+  wheelSpinning = true;
+  document.getElementById('spinBtn').disabled = true;
+  document.getElementById('wheelResult').textContent = '';
+  var totalRotation = (Math.PI * 2) * (5 + Math.random() * 5) + Math.random() * Math.PI * 2;
+  var duration = 4000 + Math.random() * 2000;
+  var startAngle = wheelAngle;
+  var startTime = performance.now();
+  function easeOutCubic(t) { return 1 - Math.pow(1 - t, 3); }
+  function animate(now) {
+    var elapsed = now - startTime;
+    var t = Math.min(elapsed / duration, 1);
+    wheelAngle = startAngle + totalRotation * easeOutCubic(t);
+    drawWheel();
+    if (t < 1) { wheelAnimId = requestAnimationFrame(animate); }
+    else { wheelSpinning = false; wheelAnimId = null; document.getElementById('spinBtn').disabled = false; announceWinner(); }
+  }
+  wheelAnimId = requestAnimationFrame(animate);
+}
+
+function announceWinner() {
+  if (wheelEntries.length === 0) return;
+  var n = wheelEntries.length;
+  var sliceAngle = (Math.PI * 2) / n;
+  var pointerRad = -Math.PI / 2;
+  var offset = pointerRad - wheelAngle;
+  offset = ((offset % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2);
+  var winnerIndex = Math.floor(offset / sliceAngle) % n;
+  var winner = wheelEntries[winnerIndex];
+  var resultEl = document.getElementById('wheelResult');
+  resultEl.innerHTML = '<span class="text-warning">' + escapeHtml(winner.name) + '</span>';
+  resultEl.style.transition = 'none'; resultEl.style.textShadow = '0 0 20px gold';
+  setTimeout(function() { resultEl.style.transition = 'text-shadow 1s'; resultEl.style.textShadow = 'none'; }, 50);
+  fireConfetti();
+}
+
+function fireConfetti() {
+  var modal = document.querySelector('#wheelModal .modal-body');
+  var rect = modal.getBoundingClientRect();
+  var particles = [];
+  var colors = ['#ffd700','#ff6b6b','#4ecdc4','#45b7d1','#f9ca24','#6c5ce7','#fd79a8','#00b894','#e17055','#0984e3'];
+  for (var i = 0; i < 150; i++) {
+    particles.push({ x: rect.width/2, y: rect.height/2, vx: (Math.random()-0.5)*16, vy: (Math.random()-1)*14-2,
+      color: colors[Math.floor(Math.random()*colors.length)], size: Math.random()*8+3, rotation: Math.random()*360,
+      rotSpeed: (Math.random()-0.5)*12, gravity: 0.15+Math.random()*0.1, opacity: 1, shape: Math.random()>0.5?'rect':'circle' });
+  }
+  var canvas = document.createElement('canvas'); canvas.width = rect.width; canvas.height = rect.height;
+  canvas.style.cssText = 'position:absolute;top:0;left:0;pointer-events:none;z-index:9999;';
+  modal.style.position = 'relative'; modal.appendChild(canvas);
+  var ctx = canvas.getContext('2d'); var startTime = performance.now(); var duration = 3000;
+  function animateConfetti(now) {
+    var elapsed = now - startTime;
+    if (elapsed > duration) { canvas.remove(); return; }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    particles.forEach(function(p) {
+      p.x += p.vx; p.vy += p.gravity; p.y += p.vy; p.vx *= 0.99; p.rotation += p.rotSpeed;
+      if (elapsed > duration * 0.6) p.opacity = Math.max(0, 1 - (elapsed - duration*0.6) / (duration*0.4));
+      ctx.save(); ctx.translate(p.x, p.y); ctx.rotate(p.rotation * Math.PI / 180);
+      ctx.globalAlpha = p.opacity; ctx.fillStyle = p.color;
+      if (p.shape === 'rect') ctx.fillRect(-p.size/2, -p.size/4, p.size, p.size/2);
+      else { ctx.beginPath(); ctx.arc(0, 0, p.size/2, 0, Math.PI*2); ctx.fill(); }
+      ctx.restore();
+    });
+    requestAnimationFrame(animateConfetti);
+  }
+  requestAnimationFrame(animateConfetti);
+}
 </script>
 </body>
 </html>

--- a/solo-data.js
+++ b/solo-data.js
@@ -1,0 +1,1368 @@
+window.soloData = {
+  "season": 13,
+  "updatedDate": "March 23rd 2026",
+  "bannerText": "Currently, this is just a copy from Season 12",
+  "starterBuilds": [
+    {
+      "className": "Sorceress",
+      "buildName": "Firewall",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=78&difficulty=3&quests=1&strength=93&dexterity=0&vitality=100&energy=207&coupling=1&skills=00000000000000000000000101010001010100200000000120010020000020000100&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Volcanic+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Andariel",
+          "style": "success",
+          "pill": true
+        }
+      ]
+    },
+    {
+      "className": "Sorceress",
+      "buildName": "Chain lightning",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=75&difficulty=3&quests=1&strength=93&dexterity=0&vitality=207&energy=85&coupling=1&skills=00000000000000000000002001010020200100002000000300000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Powered+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Arcane Sanctuary",
+          "style": "warning"
+        }
+      ]
+    },
+    {
+      "className": "Sorceress",
+      "buildName": "Ice Barrage",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=74&difficulty=3&quests=1&strength=27&dexterity=0&vitality=268&energy=85&coupling=1&skills=20000001002000200000200001010000000100000000000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Glacial+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cold_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        }
+      ]
+    },
+    {
+      "className": "Sorceress",
+      "buildName": "Meteor",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=76&difficulty=3&quests=1&strength=93&dexterity=0&vitality=212&energy=85&coupling=1&skills=00000000000000000000000001010000000100000000010101202001002020000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Volcanic+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Druid",
+      "buildName": "Summons",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=80&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00000501000100000000000000000000000000000020012020010001010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+(Vigor)%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Bloodfist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Club+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Druid",
+      "buildName": "Bear - Shockwave",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Druid",
+      "buildName": "Wind Elemental",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Assassin",
+      "buildName": "Mind Blast",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Assassin",
+      "buildName": "Blade Sentinel",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=78&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100000020000000002001010001010120002000000001000001000000010000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=none%2C0%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=none%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Assassin",
+      "buildName": "Chain Lightning Sentry",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=83&dexterity=60&vitality=267&energy=0&coupling=1&skills=0001000100000100010100050000000000000000200100200000200000002000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CWitherstring%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Arcane Sanctuary",
+          "style": "warning"
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Barbarian",
+      "buildName": "Leap Attack",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Barbarian",
+      "buildName": "Big Shouts + Find Item (A2 Offensive Merc)",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        }
+      ]
+    },
+    {
+      "className": "Barbarian",
+      "buildName": "Warcry",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=75&difficulty=3&quests=1&strength=11&dexterity=0&vitality=374&energy=0&coupling=1&skills=1600010100200100202000000000010101010000000101000100000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Caster+Craft+Gloves%2C1%2Cnone&boots=none%2C0%2Cnone&belt=Caster+Craft+Belt%2C1%2Cnone%2C&amulet=Echoing+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        }
+      ]
+    },
+    {
+      "className": "Barbarian",
+      "buildName": "Bleed Double Throw",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Amazon",
+      "buildName": "Pure Summon (Decoy & Valk)",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=80&difficulty=3&quests=1&strength=95&dexterity=0&vitality=255&energy=60&coupling=1&skills=000000000000000000000103010100200120200100010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Amazon",
+      "buildName": "Lightning Strike",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Arcane Sanctuary",
+          "style": "warning"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Amazon",
+      "buildName": "Magic Arrow",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=75&difficulty=3&quests=1&strength=121&dexterity=53&vitality=211&energy=0&coupling=1&skills=000000000000000000002001200100010100000100200100002000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CNeophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Scepter%2CSpirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Archer%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Harmony+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-weapon%2C1%2C0&effect=Prayer-mercenary%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Necromancer",
+      "buildName": "Clay Golems",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=75&difficulty=3&quests=1&strength=50&dexterity=0&vitality=335&energy=0&coupling=1&skills=000000202000200100000000000000000000000012000001000000010001000010&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2Cnone%2Cnone%2CSpirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2CAncient%27s+Pledge+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Peasant+Crown%2C2%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Golemlord%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Golemlord%27s+Tomb+Wand+of+the+Archmage%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Prayer-mercenary%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Necromancer",
+      "buildName": "Teeth / Bonespear",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=269&energy=50&coupling=1&skills=000000010000010900000000202000002000200000000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Necromancer",
+      "buildName": "Dark Pact",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=70&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000101010001010100000100000000000000000001002010200000010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2Cnone%2Cnone%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=none%2C0%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=none%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "buildName": "Holy Bolt / FOH",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=84&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000010001000101010000010001000100012000010001010120002020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Build Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "buildName": "Smiter",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "buildName": "Hammerdin",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=78&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000200001000100002020000000000000010100010020000100000100&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Build Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "buildName": "Vengeance",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    }
+  ],
+  "classBuilds": {
+    "Sorceress": [
+      {
+        "buildName": "Nova",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00010000060000000000002000202001002000002001000100000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2C%2C&armor=Steel+Carapace%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Constricting+Ring%2C0%2C%2B+Faster+Cast+Rate&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life",
+            "label": "End-game Gear",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=96&difficulty=3&quests=1&strength=106&dexterity=77&vitality=307&energy=0&coupling=1&skills=01010001010000000000002000202001002000002001000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2COndal%27s+Almighty%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CGoblin+Toe%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&gloves=Dracul%27s+Grasp%2C3%2C%2B+FBR&boots=Waterwalk%2C2%2C%2B+Mana+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+ICB%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Constricting+Ring%2C0%2C%2B+Mana+per+kill&ring2=Constricting+Ring%2C0%2C%2B+Mana+per+kill&weapon=Eschuta%27s+temper%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&offhand=Spirit+Ward%2C3%2C%2B+ICB+FBR%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Sparking+Grand+Charm+%2B+life",
+            "label": "End-game Gear",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=93&difficulty=3&quests=1&strength=200&dexterity=0&vitality=0&energy=275&coupling=1&skills=00000000000000000000002000202001000100202001000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormspire%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Dark+Abyss%2C3%2C%2B+CBF%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Mana+per+kill&boots=Silkweave%2C2%2C%2B+Mana+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Mana+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C0%2C0&effect=Defiance-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr",
+            "label": "Aspirational Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Charged Bolt",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002000200020012000082000000100000000000000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2C%2C&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cb%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life",
+            "label": "End-game Gear",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Chain Lightning",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=81&difficulty=3&quests=1&strength=60&dexterity=0&vitality=335&energy=20&coupling=1&skills=00000000000000000000002000010020201100011800000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CRockfleece%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CCredendum&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Powered+Diadem%2C3%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Silkweave%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Powered+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Memory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+            "label": "Starter Gear",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002000010020202000082000000100000000000000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=Annihilus+%2B2",
+            "label": "End-game Gear",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Frost Nova",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Frozen Orb",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Ice Barrage",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blizzard",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Combustion",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Meteor",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=80&difficulty=3&quests=1&strength=60&dexterity=0&vitality=295&energy=55&coupling=1&skills=00000000000000000000000000010000000100000000010020202001002007000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CImp+Shank%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Volcanic+Diadem%2C3%2Cnone%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Volcanic+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Memory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0",
+            "label": "Starter Gear",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Hydra",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Multishot Enchantress",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00200000010000002000200000010000000100000000011700000100200001000100&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CTemplar%27s+Might%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Caduceus%2CShattered+Wall+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CMagefist%2CImp+Shank%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Nightwing%27s+Veil%2C3%2C%2B+Skill%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magnus%27+Skin%2C2%2C%2B+Pierce&boots=Imp+Shank%2C2%2Cnone&belt=Razortail%2C2%2C%2B+Pierce%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&weapon=Widowmaker%2C3%2C%2B+IAS%2C%2C%2C%2C%2C%2C&offhand=Echo+Quiver+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Sharp+Arrows%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cold_Mastery%2C1%2C0&effect=Fire_Mastery%2C1%2C0&effect=Prayer-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Holy_Freeze-mercenary_offhand%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life",
+            "label": "End-game Gear",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      }
+    ],
+    "Druid": [
+      {
+        "buildName": "Cold Elemental (Arctic Blast/Hurricane)",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Wind Elemental",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=90&difficulty=3&quests=1&strength=185&dexterity=80&vitality=130&energy=0&coupling=1&skills=00000420000120002000200000000000000000000000010100011100010100&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2CRal+Rune%2COrt+Rune&armor=Steel+Carapace%2C3%2C%2B+Skill%2C%2C%2C%2C%2CRal+Rune%2CCham+Rune&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+FHR%2C&amulet=Gaea%27s+Amulet%2C0%2C%2B+Faster+Cast+Rate%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Horizon%27s+Tornado%2C3%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Twilight%27s+Reflection%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CShael+Rune%2CShael+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Elemental",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=97&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=01200101200101200120010000000000000000000001010101011201010101&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormlash%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CTrang-Oul%27s+Claws%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Ravenlore%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Mana+per+kill&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Gaea%27s+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Mana+per+kill&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Life+per+kill&weapon=Mang+Song%27s+Lesson%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life",
+            "label": "End-game Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Wolf - Fire Claws",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Rabies",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002020002000200000000100200100010100010100&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CHowltusk%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CPus+Spitter%2CAetherwing%2CDracul%27s+Grasp%2CTancred%27s+Hobnails%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Jalal%27s+Mane%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Bramble+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Mana+per+kill&boots=Waterwalk%2C2%2C%2B+Faster+Run+Walk&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Faster+Run+Walk%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Run%2FWalk&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Run%2FWalk&weapon=Plague+Bearer%2C2%2C%2B+Sockets+Weapon%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Stormshield%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Thorns-armor%2C1%2C0&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Bear - Shockwave",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000001000120002000000015200001000000200000010100010100010100&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVampire+Gaze%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CWrath+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2Cnone%2CDracul%27s+Grasp%2CWar+Traveler%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2C%2C&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Soul+Drainer%2C3%2C%2B+Faster+Cast+Rate&boots=Merman%27s+Sprocket%2C3%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Communal+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Brimstone+Rain%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw",
+            "label": "End-game Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Wolf - Fury",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Summon Druid",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=80&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00000501000100000000000000000000000000000020012020010001010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Bloodfist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Club+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+            "label": "Starter Build",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=85&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Grizzly%2C1%2Cnone%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm",
+            "label": "Mid Build",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=85&difficulty=3&quests=1&strength=135&dexterity=0&vitality=300&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Ravenlore%2C3%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Eaglehorn%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Conviction-mercenary_weapon%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm",
+            "label": "Endgame - Raven",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=140&dexterity=0&vitality=295&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010011010020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Denmother%2C3%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Heart+of+the+Oak+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Flail%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+Ward%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm",
+            "label": "Endgame - Bears",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=140&dexterity=0&vitality=295&energy=0&coupling=1&skills=00001001000100000000000000000000000000000011012020010020010020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm",
+            "label": "Endgame - Spirit Wolf",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      }
+    ],
+    "Assassin": [
+      {
+        "buildName": "Chain Lightning Sentry",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0000000000000000000101030004010000000000200100200000200000002000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CDuskdeep%2CRockfleece%2CPus+Spitter%2CRamfodder%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem%2C3%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+            "label": "Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Wake of Fire",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=81&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0000000000000000000101030006010000000000202000002000002000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CDuskdeep%2CRockfleece%2CPus+Spitter%2CRamfodder%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem%2C3%2Cnone%2C%2C%2C&armor=Skullder%27s+Ire%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+            "label": "Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=95&difficulty=3&quests=1&strength=40&dexterity=0&vitality=330&energy=0&coupling=1&skills=0001000100000100200101010015010001000000200001002001002000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CVampire+Gaze%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CMarrowwalk%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Assassin%2C3%2C%2B+CBF%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=War+Traveler%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Metalgrid%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Run%2FWalk&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Run%2FWalk&weapon=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor&offhand=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=Annihilus+%2B2",
+            "label": "Claw End-game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=97&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0001000100000100200101010002010001000015200001002001002000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CHeavenly+Garb%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem+of+the+Magus%2C3%2C%2B+Skill%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Chains+of+Honor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+ICB&boots=Marrowwalk%2C3%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+PDR%2C&amulet=Cunning+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Damage+Reduction&ring2=Wisp+Projector%2C0%2C%2B+Damage+Reduction&weapon=Ghostflame%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Gerke%27s+Sanctuary%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B3%25+Inferno+Large+Charm+of+Balance",
+            "label": "Dagger End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Summon Sin (Martial Arts)",
+        "tier": "Decent",
+        "links": [],
+        "notes": [
+          "Requires Skill Charms"
+        ]
+      },
+      {
+        "buildName": "Cobra Sin",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=88&difficulty=3&quests=1&strength=150&dexterity=68&vitality=232&energy=0&coupling=1&skills=0101000120000100012001030005010120002000000001000001000000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormspire%2Cnone%2CLava+Gout%2CImp+Shank%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Kenshi%27s+Gloves+of+Quickness%2C1%2C%2B+All+Resistances&boots=Imp+Shank%2C2%2C%2B+FBR&belt=Siggard%27s+Staunch%2C3%2C%2B+PDR%2C&amulet=Blood+Craft+-+Assassin%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Attack+Rating&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Attack+Rating&weapon=Jade+Talon%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Whispering+Mirage%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+fhr&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=Ruby+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Phoenix Strike",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=77&difficulty=3&quests=1&strength=0&dexterity=0&vitality=395&energy=0&coupling=1&skills=0100200001200020000100010001000000000000000001000001000000010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2CPus+Spitter%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2Cnone%2C%2C%2C&armor=Stone+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Kenshi%27s+Gloves+of+Giant%2C1%2Cnone&boots=Merman%27s+Sprocket%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Blood+Craft+-+Assassin%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Dual+Leech+Ring%2C0%2Cnone&weapon=Bartuc%27s+Cut+Throat%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Bartuc%27s+Cut+Throat%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Shogukusha%27s+Grand+Charm",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Tail (Fire Kick) Stalker's Cull",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Tail (Fire Kick) Astreons + Phoenix RW",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=91&difficulty=3&quests=1&strength=140&dexterity=130&vitality=195&energy=0&coupling=1&skills=0020000100002000200101200001010001000002000001000001000000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CMarrowwalk%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Fortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+Deadly+Strike&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+x+Enhanced+Damage%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&ring2=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&weapon=Astreon%27s+Iron+Ward%2C3%2C%2B+Sockets+Weapon%2C%2C%2CLo+Rune%2CLo+Rune%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Phoenix+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Monarch%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Redemption-offhand%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Blade Fury",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blade Sentinel (Phys)",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blade Sentinel (Venom)",
+        "tier": "Top",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Summon Sin (Mind Blast)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://tinyurl.com/s11mindblast&amp;sa=D&amp;source=editors&amp;ust=1757267248684136&amp;usg=AOvVaw1PC2217VwizNE0QTZQMnft",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Physical Blade Dance (Chaos - Phys Dmg Focus)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://tinyurl.com/s8bladedance&amp;sa=D&amp;source=editors&amp;ust=1757267248684611&amp;usg=AOvVaw3_iB8yjpdDyxVgPEqWoEHv",
+            "label": "Generic WWsin Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Poison Blade Dance (Chaos - Venom Dmg Focus)",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=84&dexterity=30&vitality=296&energy=0&coupling=1&skills=0100000020000000002000200006000100002000000001000001000000010000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVampire+Gaze%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDemon+Machine%2CDoom%27s+Finger%2CBloodfist%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Natalya%27s+Totem%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Natalya%27s+Shadow%2C3%2C%2B+Skill%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Venom+Grip%2C2%2C%2B+ICB&boots=Natalya%27s+Soul%2C2%2C%2B+Faster+Run+Walk&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Faster+Run+Walk%2C&amulet=Blood+Craft+-+Assassin%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&ring2=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&weapon=Natalya%27s+Mark%2C3%2C%2B+Psn+Pierce%2C%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Chaos+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Fist%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=Ruby+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://www.google.com/url?q=https://tinyurl.com/s8bladedance&amp;sa=D&amp;source=editors&amp;ust=1757267248684884&amp;usg=AOvVaw361TEiP3HC1zKq2oOD4LHs",
+            "label": "Generic WWsin Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": [
+          "Must gear swap pre-buff"
+        ]
+      }
+    ],
+    "Barbarian": [
+      {
+        "buildName": "Warcry",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Travbarb",
+        "tier": "Travincal",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=90&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0101010120200900012000000000010120050000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Thieves%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CArioc%27s+Needle%2Cnone%2CLaying+of+Hands%2CInfernostride%2CGoldwrap&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Crown+of+Thieves%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Chance+Guards%2C1%2C%2B+Faster+Cast+Rate&boots=Infernostride%2C2%2C%2B+Faster+Run+Walk&belt=Goldwrap%2C1%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Barbarian%2C0%2C%2B+Faster+Run+Walk%2C&ring1=Dwarf+Star%2C0%2C%2B+Faster+Cast+Rate&ring2=Dwarf+Star%2C0%2C%2B+Faster+Cast+Rate&weapon=Blade+of+Ali+Baba%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Blade+of+Ali+Baba%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Blessed_Aim-mercenary%2C1%2C0&charm=Gheed%27s+Fortune&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed",
+            "label": "End-game Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Whirlwind (2x Flamebellow)",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100000100000100002020000100010120051601010000000000002001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+All+Resistances&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+Faster+Run+Walk%2C&amulet=The+Rising+Sun%2C0%2C%2B+Faster+Run+Walk%2C&ring1=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&ring2=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&weapon=Flamebellow%2C3%2C%2B+Fire+Pierce%2C%2C%2C%2C%2C%2C&offhand=Flamebellow%2C3%2C%2B+Fire+Pierce%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Holy_Fire-armor%2C0%2C0&effect=Holy_Fire-weapon%2C0%2C0&effect=Holy_Fire-combined%2C1%2C0&effect=Holy_Fire-offhand%2C0%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm",
+            "label": "End-game Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Whirlwind (2-H)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248685787&amp;usg=AOvVaw3TaX-_ZjjfElauMuEMEOcp",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": [
+          "4 range adder weapon only",
+          "must weapon swap for frenzy"
+        ]
+      },
+      {
+        "buildName": "Whirlwind (Dual Wield)",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100010100000120012001002000010110010801010000000000002001&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Halaberd%27s+Reign%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Tyrael%27s+Might%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Soul+Drainer%2C3%2C%2B+All+Resistances&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+Faster+Run+Walk%2C&amulet=Atma%27s+Scarab%2C0%2C%2B+2+All+Skills%2C&ring1=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&ring2=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&weapon=The+Grandfather%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=Schaefer%27s+Hammer%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Expert%27s+Grand+Charm+%2B+frw",
+            "label": "End-game Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248686138&amp;usg=AOvVaw3p5jaWKspgdKbaJvQ0Yzy3",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Leap Attack (Physical)",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248686379&amp;usg=AOvVaw1YtzVDFBx7zRYXXLb7fwLe",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": [
+          "Eth Obedience or Reapers toll as starter weapon"
+        ]
+      },
+      {
+        "buildName": "Leap Attack (Ele Proc)",
+        "tier": "Decent",
+        "links": [],
+        "notes": [
+          "Stormspire | Rapture | Destruction",
+          "Infinity Merc",
+          "Ele % LC"
+        ]
+      },
+      {
+        "buildName": "Double Throw",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=91&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100010100000101010100002020010101010100000000200000000001&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CDuskdeep%2CLeviathan%2CCranebeak%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Demonhorn%27s+Edge%2C3%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2Cnone&boots=Gore+Rider%2C2%2Cnone&belt=Nosferatu%27s+Coil%2C3%2Cnone%2C&amulet=Highlord%27s+Wrath%2C0%2Cnone%2C&ring1=Raven+Frost%2C0%2Cnone&ring2=Bul-Kathos%27+Death+Band%2C0%2Cnone&weapon=Lacerator%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2CRuby+Jewel+of+Fervor&offhand=Lacerator%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=Lucky+Grand+Charm+of+Greed&charm=Sharp+Grand+Charm+of+Quality&charm=%2B1+Fanatic+Grand+Charm&charm=%2B1+Fanatic+Grand+Charm&charm=%2B1+Fanatic+Grand+Charm&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=91&difficulty=3&quests=1&strength=180&dexterity=170&vitality=115&energy=0&coupling=1&skills=0100010100000101012000000111010101012000000000200000000020&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CAndariel%27s+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CBlacktongue%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Steelrend%2C3%2C%2B+Deadly+Strike&boots=Gore+Rider%2C2%2C%2B+PDR&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+CBF%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=Constricting+Ring%2C0%2Cnone&weapon=Wraith+Flight%2C3%2C%2B+ED+Deadly%2C%2C%2C%2C%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel&offhand=Lacerator%2C3%2C%2B+IAS+Enhanced+Damage%2C%2C%2C%2C%2CRuby+Jewel+of+Fervor%2CCham+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://www.google.com/url?q=https://docs.google.com/document/d/1pL10s0YlRA5gLcFFDWh1oKYb-32a4skQkmsikMsT2sc/edit?tab%3Dt.0%23heading%3Dh.7ng7k3wkxynr&amp;sa=D&amp;source=editors&amp;ust=1757267248686857&amp;usg=AOvVaw39MsO3qC51YEI_uUeKs5R8",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": []
+      }
+    ],
+    "Amazon": [
+      {
+        "buildName": "Lightning Fury",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=96&difficulty=3&quests=1&strength=0&dexterity=106&vitality=384&energy=0&coupling=1&skills=012001002000010000200101011000011000002000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+CBF%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Pierce%2C&amulet=Blood+Craft+-+Amazon%2C0%2C%2B+2+All+Skills%2C&ring1=Constricting+Ring%2C0%2C%2B+Life+per+kill&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Mana+per+kill&weapon=Thunderstroke%2C3%2C%2B+IAS+Crushing+Blow%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&offhand=Lidless+Wall%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor%2CLPK%2FMPK+Jewel&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B3%25+Conduit+Large+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=Shimmering+Small+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Lightning Strike",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Power Strike",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Plague Javelin",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Freezing Arrow",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Cold Arrow",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=90&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000101010100001700002020200000200000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CCrown+of+Ages%2CFortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CAbyssal+Ward%2CLaying+of+Hands%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Nightwing%27s+Veil%2C3%2Cnone%2C%2C%2C&armor=Silks+of+the+Victor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Archer%27s+of+Quickness%2C1%2Cnone&boots=Merman%27s+Sprocket%2C3%2Cnone&belt=Snowclash%2C2%2Cnone%2C&amulet=Blood+Craft+-+Amazon%2C0%2Cnone%2C&ring1=The+Stone+of+Jordan%2C0%2Cnone&ring2=The+Stone+of+Jordan%2C0%2Cnone&weapon=Pus+Spitter%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Frozen+Sorrow%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Numbing+Large+Charm&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia",
+            "label": "Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Lighting Arrow",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Arrow",
+        "tier": "Top",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Explosive Arrow",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Jab/Fend",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=95&difficulty=3&quests=1&strength=44&dexterity=77&vitality=364&energy=0&coupling=1&skills=200000200000002000000120010100200200000100000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CGiant+Skull%2CBlack+Hades%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CAnvilguard+Strap%2CLava+Gout%2CGore+Rider%2CRazortail&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CVex+Rune%2CVex+Rune%2CVex+Rune&armor=Shaftstop%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Increased+Attack+Speed&boots=Gore+Rider%2C2%2C%2B+PDR&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Metalgrid%2C0%2C%2B+CBF%2C&ring1=Bul-Kathos%27+Death+Band%2C0%2C%2B+Damage+Reduction&ring2=Raven+Frost%2C0%2C%2B+Damage+Reduction&weapon=Stoneraven%2C3%2C%2B+Sockets+Weapon%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Multiple Shot",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=HzPLfKwjhqA",
+            "label": "S12 Video",
+            "type": "video"
+          },
+          {
+            "url": "https://docs.google.com/spreadsheets/d/1Mcmwpn5CkyR7BdEOlj1BuQIE-PxYHXtax3WywsBKeL8/edit?gid=944046235#gid=944046235",
+            "label": "Spreadsheet",
+            "type": "video"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Strafe (Demon Machine)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=91&difficulty=3&quests=1&strength=55&dexterity=270&vitality=140&energy=0&coupling=1&skills=000000000000000000000120010500202000021000010100000100200000&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CAndariel%27s+Visage%2CFortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Berserker+Axe%2Cnone%2CLaying+of+Hands%2CGore+Rider%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Valkyrie+Wing%2C2%2C%2B+Sockets+Helm%2C%2C%2CRuby+Jewel&armor=Fortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Goblin+Toe%2C1%2Cnone&belt=Razortail%2C2%2Cnone%2C&amulet=Atma%27s+Scarab%2C0%2Cnone%2C&ring1=Carrion+Wind%2C0%2Cnone&ring2=Raven+Frost%2C0%2Cnone&weapon=Demon+Machine%2C2%2C%2B+Sockets+Weapon%2C%2C%2CRuby+Jewel%2CRuby+Jewel%2CRuby+Jewel%2CScintillating+Jewel+of+Fervor&offhand=Shatterhead%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Gheed%27s+Fortune&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Ruby+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Serpent%27s+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita",
+            "label": "Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=96&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120011100202000001100010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVeil+of+Steel%2CTemplar%27s+Might%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CShatterhead%2CLaying+of+Hands%2CGoblin+Toe%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2CScintillating+Jewel+of+Freedom%2CScintillating+Jewel+of+Freedom%2CRuby+Jewel+of+Carnage&armor=Tyrael%27s+Might%2C3%2C%2B+Faster+Run+Walk%2C%2C%2C%2C%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage&gloves=Soul+Drainer%2C3%2C%2B+Enhanced+Damage&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=Razortail%2C2%2C%2B+Faster+Run+Walk%2C&amulet=Atma%27s+Scarab%2C0%2C%2B+Enhanced+Damage%2C&ring1=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&ring2=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&weapon=Demon+Machine%2C2%2C%2B+Sockets+Weapon%2C%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage&offhand=Shatterhead%2C0%2C%2B+Enhanced+Damage%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Gheed%27s+Fortune&charm=Shimmering+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Magic Arrow",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Summon Zon",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000102010000200120200500010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CCow+King%27s+Horns%2CCow+King%27s+Hide%2CThe+Iron+Jang+Bong%2Cnone%2CMagefist%2CImp+Shank%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Tarnhelm%2C1%2Cnone%2C%2C%2C&armor=Peace+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Goldwrap%2C1%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Dual+Leech+Ring%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Loyalty+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=80&difficulty=3&quests=1&strength=95&dexterity=0&vitality=255&energy=60&coupling=1&skills=000000000000000000000103010100200120200100010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Manald+Heal%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C",
+            "label": "Alt Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=85&difficulty=3&quests=1&strength=95&dexterity=0&vitality=280&energy=60&coupling=1&skills=000000000000000000000105010100200120200400010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CRockstopper%2CRockfleece%2CWitchwild+String%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Valkyrie+Wing%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Passion+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lidless+Wall%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm",
+            "label": "Mid Solo Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000101010100200120201600010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2CSkystrike%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Athlete%27s+Diadem+of+the+Magus%2C3%2Cnone%2C%2C%2C&armor=Peace+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Athlete%27s+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Raven+Frost%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Loyalty+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm",
+            "label": "Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=99&difficulty=3&quests=1&strength=95&dexterity=0&vitality=280&energy=60&coupling=1&skills=011100000000000000000101010100200120201000010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2COndal%27s+Almighty%2CTemplar%27s+Might%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2COccultist%2CMarrowwalk%2CArachnid+Mesh&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Athlete%27s+Diadem%2C3%2C%2B+Skill%2C%2C%2C&armor=Spirit+Shroud%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Infernostride%2C2%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2Cnone&ring2=The+Stone+of+Jordan%2C0%2Cnone&weapon=Mist+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Colossus+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary_armor%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&effect=Concentration-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Arcane+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw",
+            "label": "End-Game Rich Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Pure Summon",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://docs.google.com/spreadsheets/d/1Mcmwpn5CkyR7BdEOlj1BuQIE-PxYHXtax3WywsBKeL8/edit?gid%3D1318666241%23gid%3D1318666241&amp;sa=D&amp;source=editors&amp;ust=1757267248689986&amp;usg=AOvVaw2YhawQKfIMu0mOzznuuSii",
+            "label": "Build Guide (Solo leveling tab)",
+            "type": "guide"
+          }
+        ],
+        "notes": [
+          "Loyalty RW & Amp merc"
+        ]
+      }
+    ],
+    "Necromancer": [
+      {
+        "buildName": "Poison Nova",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=99&difficulty=3&quests=1&strength=36&dexterity=0&vitality=0&energy=469&coupling=1&skills=000101011001011500001220010201200000002001000001000000010000010000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CGriffon%27s+Eye%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Necromancer%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Skullder%27s+Ire%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Trang-Oul%27s+Girth%2C3%2Cnone%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Death%27s+Web%2C3%2C%2B+Psn+Pierce%2C%2C%2C%2C%2C%2C&offhand=Trang-Oul%27s+Wing%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B1+Fungal+Grand+Charm+%2B+fhr",
+            "label": "Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Desecrate",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Poison Strike",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=81&dexterity=53&vitality=226&energy=50&coupling=1&skills=000000010500100100000020012001200000000000000000000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Angelic+Mantle%2C1%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Sigon%27s+Gage%2C1%2Cnone&boots=Sigon%27s+Sabot%2C1%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Angelic+Wings%2C0%2Cnone%2C&ring1=Angelic+Halo%2C0%2Cnone&ring2=Angelic+Halo%2C0%2Cnone&weapon=The+Jade+Tan+Do%2C1%2C%2B+Sockets+Weapon%2C%2C%2C%2CShael+Rune%2CShael+Rune%2CShael+Rune&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Poison+Strike%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=90&difficulty=3&quests=1&strength=83&dexterity=53&vitality=224&energy=100&coupling=1&skills=000000011500150701000020012001200000000000000000000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CRockstopper%2CRockfleece%2CPus+Spitter%2Cnone%2CLava+Gout%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Trang-Oul%27s+Guise%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Trang-Oul%27s+Scales%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Increased+Attack+Speed&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Trang-Oul%27s+Girth%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Angelic+Wings%2C0%2C%2B+All+Skills%2C&ring1=Raven+Frost%2C0%2C%2B+Life+per+kill&ring2=Angelic+Halo%2C0%2C%2B+Life+per+kill&weapon=Blackbog%27s+Sharp%2C2%2C%2B+Sockets+Weapon%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CShael+Rune%2CScintillating+Jewel+of+Fervor&offhand=Trang-Oul%27s+Wing%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm",
+            "label": "Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=86&difficulty=3&quests=1&strength=20&dexterity=40&vitality=380&energy=0&coupling=1&skills=000000012000011300000020012001200000000000000000000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2Cnone%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CBloodfist%2CSandstorm+Trek%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Innocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Marrowwalk%2C3%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+All+Resistances%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Mana+per+kill&weapon=Plague+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Cinquedeas%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Martyrdom%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cleansing-weapon%2C1%2C0&effect=Prayer-mercenary%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Corpse Explosion",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=0&energy=0&coupling=1&skills=000101010001010500002001000020200000000020000000000000000000000000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Spirit+Forge%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Corpse+Explosion%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Corpse+Explosion%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=102&dexterity=0&vitality=0&energy=378&coupling=1&skills=000101010101011501002001010120200000000020000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CMarrowwalk%2CNosferatu%27s+Coil&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Corpsemourn%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&gloves=Magefist%2C1%2C%2B+Mana+per+kill&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Max+Resist%2C&amulet=Venomous+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Life+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Mang+Song%27s+Lesson%2C3%2C%2B+Sockets+Weapon%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Inferno+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=102&dexterity=0&vitality=0&energy=378&coupling=1&skills=000101010101011501002001010120200000000020000000000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CDream+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2COrmus%27+Robes%2CEschuta%27s+temper%2CDream+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CTrang-Oul%27s+Claws%2CMarrowwalk%2CArachnid+Mesh&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Ormus%27+Robes%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Venomous+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Mana+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Death%27s+Web%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Darkforce+Spawn%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Shock-mercenary_helm%2C0%2C0&effect=Holy_Shock-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Inferno+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm",
+            "label": "Alt End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Elemental Summoner (Mage Skeles + Ele Revives)",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=92&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=200101010120010101002000010100000000000001000001000000010001200010&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CImp+Shank%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Harlequin+Crest%2C3%2C%2B+Skill%2C%2CUm+Rune%2CUm+Rune&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Gravepalm%2C2%2C%2B+Faster+Cast+Rate&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+Faster+Cast+Rate%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Grim%27s+Burning+Dead%2C2%2C%2B+All+Skills%2C%2C%2CIst+Rune%2CIst+Rune%2CIst+Rune%2CScintillating+Jewel+of+Freedom&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=Amber+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Golems",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000202000200120200000000000000000000001000001000000010000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CGore+Rider%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Golemlord%27s+Diadem+of+the+Magus%2C3%2C%2B+Skill%2C%2C%2C&armor=Trang-Oul%27s+Scales%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Golemlord%27s+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Golemlord%27s+Tomb+Wand+of+the+Archmage%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=Golemlord%27s+Minion+Skull+of+the+Archmage%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life",
+            "label": "Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Green Goblin (Demon Machine Merc + Skeletons)",
+        "tier": "Good",
+        "links": [],
+        "notes": [
+          "Must gear swap pre-buff",
+          "Must have Innocence on Merc"
+        ]
+      },
+      {
+        "buildName": "Pure Revive (Eternity + Sacred Totem)",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dark Pact",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=95&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000010100010101000000010100000000000020012001200000010016000020&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CVeil+of+Steel%2CPurgatory%2Cnone%2Cnone%2CSteelrend%2CWar+Traveler%2CNosferatu%27s+Coil&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Accursed+Diadem%2C3%2C%2B+Skill%2C%2CLPK%2FMPK+req+FHR+Jewel%2CLPK%2FMPK+req+FHR+Jewel&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Mana+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Accursed+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Mana+per+kill&weapon=Blackhand+Key%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2CLPK%2FMPK+Jewel%2CLPK%2FMPK+Jewel&offhand=Darkforce+Spawn%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Hexing+Grand+Charm+%2B+fhr&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=Emerald+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Teeth / Bonespear",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=269&energy=50&coupling=1&skills=000000010000010900000000202000002000200000000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      }
+    ],
+    "Paladin": [
+      {
+        "buildName": "Holy Bolt / FOH",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=80&difficulty=3&quests=1&strength=40&dexterity=0&vitality=370&energy=0&coupling=1&skills=010001000000010003000000000000000000000000012000010001010120002020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CRockfleece%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Rose+Branded+Diadem%2C3%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Rose+Branded+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Scepter%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=82&difficulty=3&quests=1&strength=66&dexterity=80&vitality=274&energy=0&coupling=1&skills=010001000000010001000000000000000000000001012001010101010120012020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CVampire+Gaze%2CHeavenly+Garb%2CStormspire%2Cnone%2CLava+Gout%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griswold%27s+Valor%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C&armor=Griswold%27s+Heart%2C3%2C%2B+Max+Cold+Resist%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Waterwalk%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Griswold%27s+Redemption%2C3%2Cnone%2C%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune&offhand=Griswold%27s+Honor%2C3%2C%2B+Max+Poison+Resist%2C%2C%2C%2CPerfect+Diamond%2CPerfect+Diamond%2CPerfect+Diamond&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=Annihilus&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance",
+            "label": "Mid-Game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=66&dexterity=0&vitality=439&energy=0&coupling=1&skills=010602040006010001000000000000000000000001012001010101010120012020&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CCrown+of+Ages%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CAzurewrath%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CVenom+Grip%2CTancred%27s+Hobnails%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griswold%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C&armor=Griswold%27s+Heart%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+FBR&boots=Waterwalk%2C3%2C%2B+Max+Poison+Resist&belt=Arachnid+Mesh%2C3%2C%2B+PDR%2C&amulet=Rose+Branded+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Damage+Reduction&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Damage+Reduction&weapon=Griswold%27s+Redemption%2C3%2C%2B+All+Skills%2C%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune&offhand=Griswold%27s+Honor%2C3%2C%2B+All+Skills%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Sanctuary-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B1+Lion+Branded+Grand+Charm+%2B+fhr&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B3%25+Scintillating+Large+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Hammerdin",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000200000000100002020000000000001010101010120000000200100&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CGriffon%27s+Eye%2CDark+Abyss%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Paladin%2C3%2C%2B+Skill%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Paladin%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Akarat%27s+Devotion%2C3%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Herald+of+Zakarum%2C1%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Vengeance 2H Zenith",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120010000032001002001010001012000000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Griswold%27s+Heart%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Zenith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Colossus+Sword%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Salvation-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Vengeance 1H",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120010000032001002001010001012000000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Griswold%27s+Heart%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Lightsabre%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=Dragonscale%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Resist_Lightning-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Ele - Sacrifice (Native Ele Aura)",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Ele - Charge (Native Ele Aura)",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Shock - Multishot (Native Ele Aura)",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Auradin - Charge (HOJ + 2x Dragon)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=002000000000000000200101012000010001002001010001010100000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=The+Rising+Sun%2C0%2C%2B+2+All+Skills%2C&ring1=Raven+Frost%2C0%2C%2B+Life+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Hand+of+Justice+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Fire-armor%2C0%2C0&effect=Holy_Fire-weapon%2C0%2C0&effect=Holy_Fire-combined%2C1%2C0&effect=Holy_Fire-offhand%2C0%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Physical Zeal",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Physical Sacrifice",
+        "tier": "Mid",
+        "links": [],
+        "notes": [
+          "Requires Leech-able Mobs"
+        ]
+      },
+      {
+        "buildName": "Physical Charge (2-H)",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      }
+    ]
+  }
+};

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,0 +1,1368 @@
+{
+  "season": 13,
+  "updatedDate": "March 23rd 2026",
+  "bannerText": "Currently, this is just a copy from Season 12",
+  "starterBuilds": [
+    {
+      "className": "Sorceress",
+      "buildName": "Firewall",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=78&difficulty=3&quests=1&strength=93&dexterity=0&vitality=100&energy=207&coupling=1&skills=00000000000000000000000101010001010100200000000120010020000020000100&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Volcanic+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Andariel",
+          "style": "success",
+          "pill": true
+        }
+      ]
+    },
+    {
+      "className": "Sorceress",
+      "buildName": "Chain lightning",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=75&difficulty=3&quests=1&strength=93&dexterity=0&vitality=207&energy=85&coupling=1&skills=00000000000000000000002001010020200100002000000300000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Powered+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Arcane Sanctuary",
+          "style": "warning"
+        }
+      ]
+    },
+    {
+      "className": "Sorceress",
+      "buildName": "Ice Barrage",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=74&difficulty=3&quests=1&strength=27&dexterity=0&vitality=268&energy=85&coupling=1&skills=20000001002000200000200001010000000100000000000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Glacial+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cold_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        }
+      ]
+    },
+    {
+      "className": "Sorceress",
+      "buildName": "Meteor",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=76&difficulty=3&quests=1&strength=93&dexterity=0&vitality=212&energy=85&coupling=1&skills=00000000000000000000000001010000000100000000010101202001002020000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Volcanic+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Druid",
+      "buildName": "Summons",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=80&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00000501000100000000000000000000000000000020012020010001010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+(Vigor)%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Bloodfist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Club+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Druid",
+      "buildName": "Bear - Shockwave",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Druid",
+      "buildName": "Wind Elemental",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Assassin",
+      "buildName": "Mind Blast",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Assassin",
+      "buildName": "Blade Sentinel",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=78&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100000020000000002001010001010120002000000001000001000000010000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=none%2C0%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=none%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Assassin",
+      "buildName": "Chain Lightning Sentry",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=83&dexterity=60&vitality=267&energy=0&coupling=1&skills=0001000100000100010100050000000000000000200100200000200000002000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CWitherstring%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Arcane Sanctuary",
+          "style": "warning"
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Barbarian",
+      "buildName": "Leap Attack",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Barbarian",
+      "buildName": "Big Shouts + Find Item (A2 Offensive Merc)",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        }
+      ]
+    },
+    {
+      "className": "Barbarian",
+      "buildName": "Warcry",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=75&difficulty=3&quests=1&strength=11&dexterity=0&vitality=374&energy=0&coupling=1&skills=1600010100200100202000000000010101010000000101000100000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Caster+Craft+Gloves%2C1%2Cnone&boots=none%2C0%2Cnone&belt=Caster+Craft+Belt%2C1%2Cnone%2C&amulet=Echoing+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        }
+      ]
+    },
+    {
+      "className": "Barbarian",
+      "buildName": "Bleed Double Throw",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Amazon",
+      "buildName": "Pure Summon (Decoy & Valk)",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=80&difficulty=3&quests=1&strength=95&dexterity=0&vitality=255&energy=60&coupling=1&skills=000000000000000000000103010100200120200100010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Amazon",
+      "buildName": "Lightning Strike",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Arcane Sanctuary",
+          "style": "warning"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Amazon",
+      "buildName": "Magic Arrow",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=75&difficulty=3&quests=1&strength=121&dexterity=53&vitality=211&energy=0&coupling=1&skills=000000000000000000002001200100010100000100200100002000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CNeophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Scepter%2CSpirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Archer%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Harmony+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-weapon%2C1%2C0&effect=Prayer-mercenary%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Necromancer",
+      "buildName": "Clay Golems",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=75&difficulty=3&quests=1&strength=50&dexterity=0&vitality=335&energy=0&coupling=1&skills=000000202000200100000000000000000000000012000001000000010001000010&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2Cnone%2Cnone%2CSpirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2CAncient%27s+Pledge+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Peasant+Crown%2C2%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Golemlord%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Golemlord%27s+Tomb+Wand+of+the+Archmage%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Prayer-mercenary%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Travincal",
+          "style": "info"
+        },
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Necromancer",
+      "buildName": "Teeth / Bonespear",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=269&energy=50&coupling=1&skills=000000010000010900000000202000002000200000000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Necromancer",
+      "buildName": "Dark Pact",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=70&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000101010001010100000100000000000000000001002010200000010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2Cnone%2Cnone%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=none%2C0%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=none%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C",
+      "plannerLabel": "Base Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "buildName": "Holy Bolt / FOH",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=84&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000010001000101010000010001000100012000010001010120002020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Build Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        },
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "buildName": "Smiter",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Key Farming",
+          "style": "light",
+          "pill": true
+        },
+        {
+          "text": "Uber Tristam",
+          "style": "dark"
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "buildName": "Hammerdin",
+      "plannerUrl": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=78&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000200001000100002020000000000000010100010020000100000100&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0",
+      "plannerLabel": "Build Planner",
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "className": "Paladin",
+      "buildName": "Vengeance",
+      "plannerUrl": null,
+      "plannerLabel": null,
+      "tags": [
+        {
+          "text": "Chaos",
+          "style": "danger",
+          "pill": true
+        },
+        {
+          "text": "Early Map",
+          "style": "primary"
+        }
+      ]
+    }
+  ],
+  "classBuilds": {
+    "Sorceress": [
+      {
+        "buildName": "Nova",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00010000060000000000002000202001002000002001000100000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2C%2C&armor=Steel+Carapace%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Constricting+Ring%2C0%2C%2B+Faster+Cast+Rate&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life",
+            "label": "End-game Gear",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=96&difficulty=3&quests=1&strength=106&dexterity=77&vitality=307&energy=0&coupling=1&skills=01010001010000000000002000202001002000002001000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2COndal%27s+Almighty%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CGoblin+Toe%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&gloves=Dracul%27s+Grasp%2C3%2C%2B+FBR&boots=Waterwalk%2C2%2C%2B+Mana+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+ICB%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Constricting+Ring%2C0%2C%2B+Mana+per+kill&ring2=Constricting+Ring%2C0%2C%2B+Mana+per+kill&weapon=Eschuta%27s+temper%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&offhand=Spirit+Ward%2C3%2C%2B+ICB+FBR%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Sparking+Grand+Charm+%2B+life",
+            "label": "End-game Gear",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=93&difficulty=3&quests=1&strength=200&dexterity=0&vitality=0&energy=275&coupling=1&skills=00000000000000000000002000202001000100202001000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormspire%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Dark+Abyss%2C3%2C%2B+CBF%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Mana+per+kill&boots=Silkweave%2C2%2C%2B+Mana+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Mana+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C0%2C0&effect=Defiance-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr",
+            "label": "Aspirational Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Charged Bolt",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002000200020012000082000000100000000000000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2C%2C&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cb%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life",
+            "label": "End-game Gear",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Chain Lightning",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=81&difficulty=3&quests=1&strength=60&dexterity=0&vitality=335&energy=20&coupling=1&skills=00000000000000000000002000010020201100011800000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CRockfleece%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CCredendum&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Powered+Diadem%2C3%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Silkweave%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Powered+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Memory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+            "label": "Starter Gear",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002000010020202000082000000100000000000000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=Annihilus+%2B2",
+            "label": "End-game Gear",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Frost Nova",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Frozen Orb",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Ice Barrage",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blizzard",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Combustion",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Meteor",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=80&difficulty=3&quests=1&strength=60&dexterity=0&vitality=295&energy=55&coupling=1&skills=00000000000000000000000000010000000100000000010020202001002007000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CImp+Shank%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Volcanic+Diadem%2C3%2Cnone%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Volcanic+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Memory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0",
+            "label": "Starter Gear",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Hydra",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Multishot Enchantress",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00200000010000002000200000010000000100000000011700000100200001000100&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CTemplar%27s+Might%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Caduceus%2CShattered+Wall+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CMagefist%2CImp+Shank%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Nightwing%27s+Veil%2C3%2C%2B+Skill%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magnus%27+Skin%2C2%2C%2B+Pierce&boots=Imp+Shank%2C2%2Cnone&belt=Razortail%2C2%2C%2B+Pierce%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&weapon=Widowmaker%2C3%2C%2B+IAS%2C%2C%2C%2C%2C%2C&offhand=Echo+Quiver+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Sharp+Arrows%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cold_Mastery%2C1%2C0&effect=Fire_Mastery%2C1%2C0&effect=Prayer-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Holy_Freeze-mercenary_offhand%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life",
+            "label": "End-game Gear",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      }
+    ],
+    "Druid": [
+      {
+        "buildName": "Cold Elemental (Arctic Blast/Hurricane)",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Wind Elemental",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=90&difficulty=3&quests=1&strength=185&dexterity=80&vitality=130&energy=0&coupling=1&skills=00000420000120002000200000000000000000000000010100011100010100&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2CRal+Rune%2COrt+Rune&armor=Steel+Carapace%2C3%2C%2B+Skill%2C%2C%2C%2C%2CRal+Rune%2CCham+Rune&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+FHR%2C&amulet=Gaea%27s+Amulet%2C0%2C%2B+Faster+Cast+Rate%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Horizon%27s+Tornado%2C3%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Twilight%27s+Reflection%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CShael+Rune%2CShael+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Elemental",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=97&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=01200101200101200120010000000000000000000001010101011201010101&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormlash%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CTrang-Oul%27s+Claws%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Ravenlore%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Mana+per+kill&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Gaea%27s+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Mana+per+kill&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Life+per+kill&weapon=Mang+Song%27s+Lesson%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life",
+            "label": "End-game Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Wolf - Fire Claws",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Rabies",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002020002000200000000100200100010100010100&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CHowltusk%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CPus+Spitter%2CAetherwing%2CDracul%27s+Grasp%2CTancred%27s+Hobnails%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Jalal%27s+Mane%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Bramble+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Mana+per+kill&boots=Waterwalk%2C2%2C%2B+Faster+Run+Walk&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Faster+Run+Walk%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Run%2FWalk&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Run%2FWalk&weapon=Plague+Bearer%2C2%2C%2B+Sockets+Weapon%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Stormshield%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Thorns-armor%2C1%2C0&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Bear - Shockwave",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000001000120002000000015200001000000200000010100010100010100&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVampire+Gaze%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CWrath+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2Cnone%2CDracul%27s+Grasp%2CWar+Traveler%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2C%2C&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Soul+Drainer%2C3%2C%2B+Faster+Cast+Rate&boots=Merman%27s+Sprocket%2C3%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Communal+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Brimstone+Rain%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw",
+            "label": "End-game Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Wolf - Fury",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Summon Druid",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=80&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00000501000100000000000000000000000000000020012020010001010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Bloodfist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Club+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+            "label": "Starter Build",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=85&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Grizzly%2C1%2Cnone%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm",
+            "label": "Mid Build",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=85&difficulty=3&quests=1&strength=135&dexterity=0&vitality=300&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Ravenlore%2C3%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Eaglehorn%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Conviction-mercenary_weapon%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm",
+            "label": "Endgame - Raven",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=140&dexterity=0&vitality=295&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010011010020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Denmother%2C3%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Heart+of+the+Oak+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Flail%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+Ward%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm",
+            "label": "Endgame - Bears",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=140&dexterity=0&vitality=295&energy=0&coupling=1&skills=00001001000100000000000000000000000000000011012020010020010020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm",
+            "label": "Endgame - Spirit Wolf",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      }
+    ],
+    "Assassin": [
+      {
+        "buildName": "Chain Lightning Sentry",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0000000000000000000101030004010000000000200100200000200000002000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CDuskdeep%2CRockfleece%2CPus+Spitter%2CRamfodder%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem%2C3%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+            "label": "Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Wake of Fire",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=81&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0000000000000000000101030006010000000000202000002000002000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CDuskdeep%2CRockfleece%2CPus+Spitter%2CRamfodder%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem%2C3%2Cnone%2C%2C%2C&armor=Skullder%27s+Ire%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+            "label": "Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=95&difficulty=3&quests=1&strength=40&dexterity=0&vitality=330&energy=0&coupling=1&skills=0001000100000100200101010015010001000000200001002001002000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CVampire+Gaze%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CMarrowwalk%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Assassin%2C3%2C%2B+CBF%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=War+Traveler%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Metalgrid%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Run%2FWalk&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Run%2FWalk&weapon=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor&offhand=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=Annihilus+%2B2",
+            "label": "Claw End-game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=97&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0001000100000100200101010002010001000015200001002001002000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CHeavenly+Garb%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem+of+the+Magus%2C3%2C%2B+Skill%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Chains+of+Honor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+ICB&boots=Marrowwalk%2C3%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+PDR%2C&amulet=Cunning+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Damage+Reduction&ring2=Wisp+Projector%2C0%2C%2B+Damage+Reduction&weapon=Ghostflame%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Gerke%27s+Sanctuary%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B3%25+Inferno+Large+Charm+of+Balance",
+            "label": "Dagger End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Summon Sin (Martial Arts)",
+        "tier": "Decent",
+        "links": [],
+        "notes": [
+          "Requires Skill Charms"
+        ]
+      },
+      {
+        "buildName": "Cobra Sin",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=88&difficulty=3&quests=1&strength=150&dexterity=68&vitality=232&energy=0&coupling=1&skills=0101000120000100012001030005010120002000000001000001000000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormspire%2Cnone%2CLava+Gout%2CImp+Shank%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Kenshi%27s+Gloves+of+Quickness%2C1%2C%2B+All+Resistances&boots=Imp+Shank%2C2%2C%2B+FBR&belt=Siggard%27s+Staunch%2C3%2C%2B+PDR%2C&amulet=Blood+Craft+-+Assassin%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Attack+Rating&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Attack+Rating&weapon=Jade+Talon%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Whispering+Mirage%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+fhr&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=Ruby+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Phoenix Strike",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=77&difficulty=3&quests=1&strength=0&dexterity=0&vitality=395&energy=0&coupling=1&skills=0100200001200020000100010001000000000000000001000001000000010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2CPus+Spitter%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2Cnone%2C%2C%2C&armor=Stone+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Kenshi%27s+Gloves+of+Giant%2C1%2Cnone&boots=Merman%27s+Sprocket%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Blood+Craft+-+Assassin%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Dual+Leech+Ring%2C0%2Cnone&weapon=Bartuc%27s+Cut+Throat%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Bartuc%27s+Cut+Throat%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Shogukusha%27s+Grand+Charm",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Tail (Fire Kick) Stalker's Cull",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Tail (Fire Kick) Astreons + Phoenix RW",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=91&difficulty=3&quests=1&strength=140&dexterity=130&vitality=195&energy=0&coupling=1&skills=0020000100002000200101200001010001000002000001000001000000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CMarrowwalk%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Fortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+Deadly+Strike&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+x+Enhanced+Damage%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&ring2=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&weapon=Astreon%27s+Iron+Ward%2C3%2C%2B+Sockets+Weapon%2C%2C%2CLo+Rune%2CLo+Rune%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Phoenix+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Monarch%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Redemption-offhand%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Blade Fury",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blade Sentinel (Phys)",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blade Sentinel (Venom)",
+        "tier": "Top",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Summon Sin (Mind Blast)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://tinyurl.com/s11mindblast&amp;sa=D&amp;source=editors&amp;ust=1757267248684136&amp;usg=AOvVaw1PC2217VwizNE0QTZQMnft",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Physical Blade Dance (Chaos - Phys Dmg Focus)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://tinyurl.com/s8bladedance&amp;sa=D&amp;source=editors&amp;ust=1757267248684611&amp;usg=AOvVaw3_iB8yjpdDyxVgPEqWoEHv",
+            "label": "Generic WWsin Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Poison Blade Dance (Chaos - Venom Dmg Focus)",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=84&dexterity=30&vitality=296&energy=0&coupling=1&skills=0100000020000000002000200006000100002000000001000001000000010000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVampire+Gaze%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDemon+Machine%2CDoom%27s+Finger%2CBloodfist%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Natalya%27s+Totem%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Natalya%27s+Shadow%2C3%2C%2B+Skill%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Venom+Grip%2C2%2C%2B+ICB&boots=Natalya%27s+Soul%2C2%2C%2B+Faster+Run+Walk&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Faster+Run+Walk%2C&amulet=Blood+Craft+-+Assassin%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&ring2=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&weapon=Natalya%27s+Mark%2C3%2C%2B+Psn+Pierce%2C%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Chaos+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Fist%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=Ruby+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://www.google.com/url?q=https://tinyurl.com/s8bladedance&amp;sa=D&amp;source=editors&amp;ust=1757267248684884&amp;usg=AOvVaw361TEiP3HC1zKq2oOD4LHs",
+            "label": "Generic WWsin Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": [
+          "Must gear swap pre-buff"
+        ]
+      }
+    ],
+    "Barbarian": [
+      {
+        "buildName": "Warcry",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Travbarb",
+        "tier": "Travincal",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=90&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0101010120200900012000000000010120050000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Thieves%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CArioc%27s+Needle%2Cnone%2CLaying+of+Hands%2CInfernostride%2CGoldwrap&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Crown+of+Thieves%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Chance+Guards%2C1%2C%2B+Faster+Cast+Rate&boots=Infernostride%2C2%2C%2B+Faster+Run+Walk&belt=Goldwrap%2C1%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Barbarian%2C0%2C%2B+Faster+Run+Walk%2C&ring1=Dwarf+Star%2C0%2C%2B+Faster+Cast+Rate&ring2=Dwarf+Star%2C0%2C%2B+Faster+Cast+Rate&weapon=Blade+of+Ali+Baba%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Blade+of+Ali+Baba%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Blessed_Aim-mercenary%2C1%2C0&charm=Gheed%27s+Fortune&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed",
+            "label": "End-game Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Whirlwind (2x Flamebellow)",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100000100000100002020000100010120051601010000000000002001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+All+Resistances&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+Faster+Run+Walk%2C&amulet=The+Rising+Sun%2C0%2C%2B+Faster+Run+Walk%2C&ring1=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&ring2=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&weapon=Flamebellow%2C3%2C%2B+Fire+Pierce%2C%2C%2C%2C%2C%2C&offhand=Flamebellow%2C3%2C%2B+Fire+Pierce%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Holy_Fire-armor%2C0%2C0&effect=Holy_Fire-weapon%2C0%2C0&effect=Holy_Fire-combined%2C1%2C0&effect=Holy_Fire-offhand%2C0%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm",
+            "label": "End-game Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Whirlwind (2-H)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248685787&amp;usg=AOvVaw3TaX-_ZjjfElauMuEMEOcp",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": [
+          "4 range adder weapon only",
+          "must weapon swap for frenzy"
+        ]
+      },
+      {
+        "buildName": "Whirlwind (Dual Wield)",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100010100000120012001002000010110010801010000000000002001&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Halaberd%27s+Reign%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Tyrael%27s+Might%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Soul+Drainer%2C3%2C%2B+All+Resistances&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+Faster+Run+Walk%2C&amulet=Atma%27s+Scarab%2C0%2C%2B+2+All+Skills%2C&ring1=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&ring2=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&weapon=The+Grandfather%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=Schaefer%27s+Hammer%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Expert%27s+Grand+Charm+%2B+frw",
+            "label": "End-game Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248686138&amp;usg=AOvVaw3p5jaWKspgdKbaJvQ0Yzy3",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Leap Attack (Physical)",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248686379&amp;usg=AOvVaw1YtzVDFBx7zRYXXLb7fwLe",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": [
+          "Eth Obedience or Reapers toll as starter weapon"
+        ]
+      },
+      {
+        "buildName": "Leap Attack (Ele Proc)",
+        "tier": "Decent",
+        "links": [],
+        "notes": [
+          "Stormspire | Rapture | Destruction",
+          "Infinity Merc",
+          "Ele % LC"
+        ]
+      },
+      {
+        "buildName": "Double Throw",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=91&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100010100000101010100002020010101010100000000200000000001&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CDuskdeep%2CLeviathan%2CCranebeak%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Demonhorn%27s+Edge%2C3%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2Cnone&boots=Gore+Rider%2C2%2Cnone&belt=Nosferatu%27s+Coil%2C3%2Cnone%2C&amulet=Highlord%27s+Wrath%2C0%2Cnone%2C&ring1=Raven+Frost%2C0%2Cnone&ring2=Bul-Kathos%27+Death+Band%2C0%2Cnone&weapon=Lacerator%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2CRuby+Jewel+of+Fervor&offhand=Lacerator%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=Lucky+Grand+Charm+of+Greed&charm=Sharp+Grand+Charm+of+Quality&charm=%2B1+Fanatic+Grand+Charm&charm=%2B1+Fanatic+Grand+Charm&charm=%2B1+Fanatic+Grand+Charm&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=91&difficulty=3&quests=1&strength=180&dexterity=170&vitality=115&energy=0&coupling=1&skills=0100010100000101012000000111010101012000000000200000000020&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CAndariel%27s+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CBlacktongue%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Steelrend%2C3%2C%2B+Deadly+Strike&boots=Gore+Rider%2C2%2C%2B+PDR&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+CBF%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=Constricting+Ring%2C0%2Cnone&weapon=Wraith+Flight%2C3%2C%2B+ED+Deadly%2C%2C%2C%2C%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel&offhand=Lacerator%2C3%2C%2B+IAS+Enhanced+Damage%2C%2C%2C%2C%2CRuby+Jewel+of+Fervor%2CCham+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://www.google.com/url?q=https://docs.google.com/document/d/1pL10s0YlRA5gLcFFDWh1oKYb-32a4skQkmsikMsT2sc/edit?tab%3Dt.0%23heading%3Dh.7ng7k3wkxynr&amp;sa=D&amp;source=editors&amp;ust=1757267248686857&amp;usg=AOvVaw39MsO3qC51YEI_uUeKs5R8",
+            "label": "Build Guide",
+            "type": "guide"
+          }
+        ],
+        "notes": []
+      }
+    ],
+    "Amazon": [
+      {
+        "buildName": "Lightning Fury",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=96&difficulty=3&quests=1&strength=0&dexterity=106&vitality=384&energy=0&coupling=1&skills=012001002000010000200101011000011000002000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+CBF%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Pierce%2C&amulet=Blood+Craft+-+Amazon%2C0%2C%2B+2+All+Skills%2C&ring1=Constricting+Ring%2C0%2C%2B+Life+per+kill&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Mana+per+kill&weapon=Thunderstroke%2C3%2C%2B+IAS+Crushing+Blow%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&offhand=Lidless+Wall%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor%2CLPK%2FMPK+Jewel&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B3%25+Conduit+Large+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=Shimmering+Small+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Lightning Strike",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Power Strike",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Plague Javelin",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Freezing Arrow",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Cold Arrow",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=90&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000101010100001700002020200000200000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CCrown+of+Ages%2CFortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CAbyssal+Ward%2CLaying+of+Hands%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Nightwing%27s+Veil%2C3%2Cnone%2C%2C%2C&armor=Silks+of+the+Victor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Archer%27s+of+Quickness%2C1%2Cnone&boots=Merman%27s+Sprocket%2C3%2Cnone&belt=Snowclash%2C2%2Cnone%2C&amulet=Blood+Craft+-+Amazon%2C0%2Cnone%2C&ring1=The+Stone+of+Jordan%2C0%2Cnone&ring2=The+Stone+of+Jordan%2C0%2Cnone&weapon=Pus+Spitter%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Frozen+Sorrow%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Numbing+Large+Charm&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia",
+            "label": "Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Lighting Arrow",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Arrow",
+        "tier": "Top",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Explosive Arrow",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Jab/Fend",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=95&difficulty=3&quests=1&strength=44&dexterity=77&vitality=364&energy=0&coupling=1&skills=200000200000002000000120010100200200000100000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CGiant+Skull%2CBlack+Hades%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CAnvilguard+Strap%2CLava+Gout%2CGore+Rider%2CRazortail&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CVex+Rune%2CVex+Rune%2CVex+Rune&armor=Shaftstop%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Increased+Attack+Speed&boots=Gore+Rider%2C2%2C%2B+PDR&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Metalgrid%2C0%2C%2B+CBF%2C&ring1=Bul-Kathos%27+Death+Band%2C0%2C%2B+Damage+Reduction&ring2=Raven+Frost%2C0%2C%2B+Damage+Reduction&weapon=Stoneraven%2C3%2C%2B+Sockets+Weapon%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Multiple Shot",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=HzPLfKwjhqA",
+            "label": "S12 Video",
+            "type": "video"
+          },
+          {
+            "url": "https://docs.google.com/spreadsheets/d/1Mcmwpn5CkyR7BdEOlj1BuQIE-PxYHXtax3WywsBKeL8/edit?gid=944046235#gid=944046235",
+            "label": "Spreadsheet",
+            "type": "video"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Strafe (Demon Machine)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=91&difficulty=3&quests=1&strength=55&dexterity=270&vitality=140&energy=0&coupling=1&skills=000000000000000000000120010500202000021000010100000100200000&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CAndariel%27s+Visage%2CFortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Berserker+Axe%2Cnone%2CLaying+of+Hands%2CGore+Rider%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Valkyrie+Wing%2C2%2C%2B+Sockets+Helm%2C%2C%2CRuby+Jewel&armor=Fortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Goblin+Toe%2C1%2Cnone&belt=Razortail%2C2%2Cnone%2C&amulet=Atma%27s+Scarab%2C0%2Cnone%2C&ring1=Carrion+Wind%2C0%2Cnone&ring2=Raven+Frost%2C0%2Cnone&weapon=Demon+Machine%2C2%2C%2B+Sockets+Weapon%2C%2C%2CRuby+Jewel%2CRuby+Jewel%2CRuby+Jewel%2CScintillating+Jewel+of+Fervor&offhand=Shatterhead%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Gheed%27s+Fortune&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Ruby+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Serpent%27s+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita",
+            "label": "Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=96&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120011100202000001100010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVeil+of+Steel%2CTemplar%27s+Might%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CShatterhead%2CLaying+of+Hands%2CGoblin+Toe%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2CScintillating+Jewel+of+Freedom%2CScintillating+Jewel+of+Freedom%2CRuby+Jewel+of+Carnage&armor=Tyrael%27s+Might%2C3%2C%2B+Faster+Run+Walk%2C%2C%2C%2C%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage&gloves=Soul+Drainer%2C3%2C%2B+Enhanced+Damage&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=Razortail%2C2%2C%2B+Faster+Run+Walk%2C&amulet=Atma%27s+Scarab%2C0%2C%2B+Enhanced+Damage%2C&ring1=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&ring2=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&weapon=Demon+Machine%2C2%2C%2B+Sockets+Weapon%2C%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage&offhand=Shatterhead%2C0%2C%2B+Enhanced+Damage%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Gheed%27s+Fortune&charm=Shimmering+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Magic Arrow",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Summon Zon",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000102010000200120200500010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CCow+King%27s+Horns%2CCow+King%27s+Hide%2CThe+Iron+Jang+Bong%2Cnone%2CMagefist%2CImp+Shank%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Tarnhelm%2C1%2Cnone%2C%2C%2C&armor=Peace+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Goldwrap%2C1%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Dual+Leech+Ring%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Loyalty+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=80&difficulty=3&quests=1&strength=95&dexterity=0&vitality=255&energy=60&coupling=1&skills=000000000000000000000103010100200120200100010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Manald+Heal%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C",
+            "label": "Alt Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=85&difficulty=3&quests=1&strength=95&dexterity=0&vitality=280&energy=60&coupling=1&skills=000000000000000000000105010100200120200400010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CRockstopper%2CRockfleece%2CWitchwild+String%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Valkyrie+Wing%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Passion+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lidless+Wall%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm",
+            "label": "Mid Solo Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000101010100200120201600010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2CSkystrike%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Athlete%27s+Diadem+of+the+Magus%2C3%2Cnone%2C%2C%2C&armor=Peace+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Athlete%27s+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Raven+Frost%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Loyalty+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm",
+            "label": "Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=99&difficulty=3&quests=1&strength=95&dexterity=0&vitality=280&energy=60&coupling=1&skills=011100000000000000000101010100200120201000010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2COndal%27s+Almighty%2CTemplar%27s+Might%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2COccultist%2CMarrowwalk%2CArachnid+Mesh&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Athlete%27s+Diadem%2C3%2C%2B+Skill%2C%2C%2C&armor=Spirit+Shroud%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Infernostride%2C2%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2Cnone&ring2=The+Stone+of+Jordan%2C0%2Cnone&weapon=Mist+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Colossus+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary_armor%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&effect=Concentration-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Arcane+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw",
+            "label": "End-Game Rich Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Pure Summon",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://www.google.com/url?q=https://docs.google.com/spreadsheets/d/1Mcmwpn5CkyR7BdEOlj1BuQIE-PxYHXtax3WywsBKeL8/edit?gid%3D1318666241%23gid%3D1318666241&amp;sa=D&amp;source=editors&amp;ust=1757267248689986&amp;usg=AOvVaw2YhawQKfIMu0mOzznuuSii",
+            "label": "Build Guide (Solo leveling tab)",
+            "type": "guide"
+          }
+        ],
+        "notes": [
+          "Loyalty RW & Amp merc"
+        ]
+      }
+    ],
+    "Necromancer": [
+      {
+        "buildName": "Poison Nova",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=99&difficulty=3&quests=1&strength=36&dexterity=0&vitality=0&energy=469&coupling=1&skills=000101011001011500001220010201200000002001000001000000010000010000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CGriffon%27s+Eye%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Necromancer%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Skullder%27s+Ire%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Trang-Oul%27s+Girth%2C3%2Cnone%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Death%27s+Web%2C3%2C%2B+Psn+Pierce%2C%2C%2C%2C%2C%2C&offhand=Trang-Oul%27s+Wing%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B1+Fungal+Grand+Charm+%2B+fhr",
+            "label": "Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Desecrate",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Poison Strike",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=81&dexterity=53&vitality=226&energy=50&coupling=1&skills=000000010500100100000020012001200000000000000000000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Angelic+Mantle%2C1%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Sigon%27s+Gage%2C1%2Cnone&boots=Sigon%27s+Sabot%2C1%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Angelic+Wings%2C0%2Cnone%2C&ring1=Angelic+Halo%2C0%2Cnone&ring2=Angelic+Halo%2C0%2Cnone&weapon=The+Jade+Tan+Do%2C1%2C%2B+Sockets+Weapon%2C%2C%2C%2CShael+Rune%2CShael+Rune%2CShael+Rune&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Poison+Strike%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=90&difficulty=3&quests=1&strength=83&dexterity=53&vitality=224&energy=100&coupling=1&skills=000000011500150701000020012001200000000000000000000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CRockstopper%2CRockfleece%2CPus+Spitter%2Cnone%2CLava+Gout%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Trang-Oul%27s+Guise%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Trang-Oul%27s+Scales%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Increased+Attack+Speed&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Trang-Oul%27s+Girth%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Angelic+Wings%2C0%2C%2B+All+Skills%2C&ring1=Raven+Frost%2C0%2C%2B+Life+per+kill&ring2=Angelic+Halo%2C0%2C%2B+Life+per+kill&weapon=Blackbog%27s+Sharp%2C2%2C%2B+Sockets+Weapon%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CShael+Rune%2CScintillating+Jewel+of+Fervor&offhand=Trang-Oul%27s+Wing%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm",
+            "label": "Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=86&difficulty=3&quests=1&strength=20&dexterity=40&vitality=380&energy=0&coupling=1&skills=000000012000011300000020012001200000000000000000000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2Cnone%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CBloodfist%2CSandstorm+Trek%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Innocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Marrowwalk%2C3%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+All+Resistances%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Mana+per+kill&weapon=Plague+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Cinquedeas%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Martyrdom%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cleansing-weapon%2C1%2C0&effect=Prayer-mercenary%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Corpse Explosion",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=0&energy=0&coupling=1&skills=000101010001010500002001000020200000000020000000000000000000000000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Spirit+Forge%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Corpse+Explosion%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Corpse+Explosion%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=102&dexterity=0&vitality=0&energy=378&coupling=1&skills=000101010101011501002001010120200000000020000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CMarrowwalk%2CNosferatu%27s+Coil&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Corpsemourn%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&gloves=Magefist%2C1%2C%2B+Mana+per+kill&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Max+Resist%2C&amulet=Venomous+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Life+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Mang+Song%27s+Lesson%2C3%2C%2B+Sockets+Weapon%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Inferno+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=102&dexterity=0&vitality=0&energy=378&coupling=1&skills=000101010101011501002001010120200000000020000000000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CDream+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2COrmus%27+Robes%2CEschuta%27s+temper%2CDream+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CTrang-Oul%27s+Claws%2CMarrowwalk%2CArachnid+Mesh&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Ormus%27+Robes%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Venomous+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Mana+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Death%27s+Web%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Darkforce+Spawn%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Shock-mercenary_helm%2C0%2C0&effect=Holy_Shock-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Inferno+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm",
+            "label": "Alt End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Elemental Summoner (Mage Skeles + Ele Revives)",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=92&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=200101010120010101002000010100000000000001000001000000010001200010&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CImp+Shank%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Harlequin+Crest%2C3%2C%2B+Skill%2C%2CUm+Rune%2CUm+Rune&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Gravepalm%2C2%2C%2B+Faster+Cast+Rate&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+Faster+Cast+Rate%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Grim%27s+Burning+Dead%2C2%2C%2B+All+Skills%2C%2C%2CIst+Rune%2CIst+Rune%2CIst+Rune%2CScintillating+Jewel+of+Freedom&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=Amber+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Golems",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000202000200120200000000000000000000001000001000000010000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CGore+Rider%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Golemlord%27s+Diadem+of+the+Magus%2C3%2C%2B+Skill%2C%2C%2C&armor=Trang-Oul%27s+Scales%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Golemlord%27s+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Golemlord%27s+Tomb+Wand+of+the+Archmage%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=Golemlord%27s+Minion+Skull+of+the+Archmage%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life",
+            "label": "Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Green Goblin (Demon Machine Merc + Skeletons)",
+        "tier": "Good",
+        "links": [],
+        "notes": [
+          "Must gear swap pre-buff",
+          "Must have Innocence on Merc"
+        ]
+      },
+      {
+        "buildName": "Pure Revive (Eternity + Sacred Totem)",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dark Pact",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=95&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000010100010101000000010100000000000020012001200000010016000020&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CVeil+of+Steel%2CPurgatory%2Cnone%2Cnone%2CSteelrend%2CWar+Traveler%2CNosferatu%27s+Coil&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Accursed+Diadem%2C3%2C%2B+Skill%2C%2CLPK%2FMPK+req+FHR+Jewel%2CLPK%2FMPK+req+FHR+Jewel&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Mana+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Accursed+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Mana+per+kill&weapon=Blackhand+Key%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2CLPK%2FMPK+Jewel%2CLPK%2FMPK+Jewel&offhand=Darkforce+Spawn%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Hexing+Grand+Charm+%2B+fhr&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=Emerald+Small+Charm+of+Vita",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Teeth / Bonespear",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=269&energy=50&coupling=1&skills=000000010000010900000000202000002000200000000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      }
+    ],
+    "Paladin": [
+      {
+        "buildName": "Holy Bolt / FOH",
+        "tier": "Mid",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=80&difficulty=3&quests=1&strength=40&dexterity=0&vitality=370&energy=0&coupling=1&skills=010001000000010003000000000000000000000000012000010001010120002020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CRockfleece%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Rose+Branded+Diadem%2C3%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Rose+Branded+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Scepter%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
+            "label": "Starter Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=82&difficulty=3&quests=1&strength=66&dexterity=80&vitality=274&energy=0&coupling=1&skills=010001000000010001000000000000000000000001012001010101010120012020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CVampire+Gaze%2CHeavenly+Garb%2CStormspire%2Cnone%2CLava+Gout%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griswold%27s+Valor%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C&armor=Griswold%27s+Heart%2C3%2C%2B+Max+Cold+Resist%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Waterwalk%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Griswold%27s+Redemption%2C3%2Cnone%2C%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune&offhand=Griswold%27s+Honor%2C3%2C%2B+Max+Poison+Resist%2C%2C%2C%2CPerfect+Diamond%2CPerfect+Diamond%2CPerfect+Diamond&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=Annihilus&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance",
+            "label": "Mid-Game Build Planner",
+            "type": "planner"
+          },
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=66&dexterity=0&vitality=439&energy=0&coupling=1&skills=010602040006010001000000000000000000000001012001010101010120012020&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CCrown+of+Ages%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CAzurewrath%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CVenom+Grip%2CTancred%27s+Hobnails%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griswold%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C&armor=Griswold%27s+Heart%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+FBR&boots=Waterwalk%2C3%2C%2B+Max+Poison+Resist&belt=Arachnid+Mesh%2C3%2C%2B+PDR%2C&amulet=Rose+Branded+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Damage+Reduction&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Damage+Reduction&weapon=Griswold%27s+Redemption%2C3%2C%2B+All+Skills%2C%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune&offhand=Griswold%27s+Honor%2C3%2C%2B+All+Skills%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Sanctuary-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B1+Lion+Branded+Grand+Charm+%2B+fhr&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B3%25+Scintillating+Large+Charm+of+Balance",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Hammerdin",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000200000000100002020000000000001010101010120000000200100&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CGriffon%27s+Eye%2CDark+Abyss%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Paladin%2C3%2C%2B+Skill%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Paladin%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Akarat%27s+Devotion%2C3%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Herald+of+Zakarum%2C1%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Vengeance 2H Zenith",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120010000032001002001010001012000000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Griswold%27s+Heart%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Zenith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Colossus+Sword%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Salvation-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Vengeance 1H",
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120010000032001002001010001012000000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Griswold%27s+Heart%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Lightsabre%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=Dragonscale%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Resist_Lightning-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Ele - Sacrifice (Native Ele Aura)",
+        "tier": "Mid",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Ele - Charge (Native Ele Aura)",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Shock - Multishot (Native Ele Aura)",
+        "tier": "Good",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Auradin - Charge (HOJ + 2x Dragon)",
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=002000000000000000200101012000010001002001010001010100000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=The+Rising+Sun%2C0%2C%2B+2+All+Skills%2C&ring1=Raven+Frost%2C0%2C%2B+Life+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Hand+of+Justice+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Fire-armor%2C0%2C0&effect=Holy_Fire-weapon%2C0%2C0&effect=Holy_Fire-combined%2C1%2C0&effect=Holy_Fire-offhand%2C0%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm",
+            "label": "End-game Build Planner",
+            "type": "planner"
+          }
+        ],
+        "notes": []
+      },
+      {
+        "buildName": "Physical Zeal",
+        "tier": "Bad",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Physical Sacrifice",
+        "tier": "Mid",
+        "links": [],
+        "notes": [
+          "Requires Leech-able Mobs"
+        ]
+      },
+      {
+        "buildName": "Physical Charge (2-H)",
+        "tier": "Decent",
+        "links": [],
+        "notes": []
+      }
+    ]
+  }
+}

--- a/solo.html
+++ b/solo.html
@@ -674,1399 +674,38 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 			</div>
 		</div>
 
+		<div class="col-sm-6 col-md-3 col-xl-auto d-flex align-items-center">
+			<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127922; Spin the Wheel</button>
+		</div>
+
 	</div>
 </div>
-<div class="pt-3 mt-4 alert alert-danger" role="alert">
-	<h2>Currently, this is just a copy from Season 12 (Updated: March 23rd 2026)</h2>
+
+<!-- Wheel Modal -->
+<div class="modal fade" id="wheelModal" tabindex="-1" aria-labelledby="wheelModalLabel" aria-hidden="true">
+	<div class="modal-dialog modal-dialog-centered modal-lg">
+		<div class="modal-content bg-dark text-white">
+			<div class="modal-header border-secondary">
+				<h5 class="modal-title" id="wheelModalLabel">&#127922; Spin the Wheel</h5>
+				<button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<div class="modal-body text-center p-2">
+				<div style="position:relative;display:inline-block;">
+					<canvas id="wheelCanvas" width="500" height="500"></canvas>
+					<div id="wheelPointer" style="position:absolute;top:10px;left:50%;transform:translateX(-50%);font-size:32px;line-height:1;filter:drop-shadow(0 2px 4px rgba(0,0,0,.6));">&#9660;</div>
+				</div>
+				<div class="mt-2">
+					<button class="btn btn-primary btn-lg px-5" id="spinBtn" onclick="spinWheel()">SPIN</button>
+				</div>
+				<div id="wheelResult" class="mt-3 fs-3 fw-bold" style="min-height:2.5rem;"></div>
+			</div>
+		</div>
+	</div>
 </div>
+
+<div id="bannerContainer"></div>
 <div class="pt-3 mt-4 border-top"></div>
-<table class="table table-striped table-dark">
-
-
-	<thead id="theadStarter">
-	<tr>
-		<td colspan="1">
-			<svg xmlns="http://www.w3.org/2000/svg"
-			     width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000"
-			     preserveAspectRatio="xMidYMid meet">
-				<g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
-				   fill="#fff" stroke="none">
-					<path d="M6 303 c4 -10 7 -36 6 -58 -2 -33 3 -44 27 -65 21 -17 36 -46 50 -93
-12 -38 18 -73 15 -78 -3 -5 33 -9 83 -9 55 0 83 4 74 9 -11 7 -12 25 -7 82 11
-112 10 126 -10 156 -10 15 -18 34 -19 42 0 8 -7 18 -17 24 -20 13 -48 -6 -48
--35 0 -25 -23 -68 -48 -91 -19 -18 -21 -17 -47 9 -20 20 -25 33 -20 51 3 16 0
-34 -10 49 -18 28 -41 33 -29 7z m28 -65 c-5 -31 -3 -38 9 -38 9 0 21 -10 27
--22 9 -20 9 -21 -2 -7 -7 8 -21 18 -32 22 -15 6 -17 14 -13 44 4 20 2 45 -4
-57 -10 20 -10 20 5 2 11 -14 14 -31 10 -58z m186 51 c0 -13 -14 -11 -28 3 -7
-7 -12 8 -12 4 0 -10 40 -46 51 -46 6 0 29 -54 29 -70 0 -4 -9 -17 -20 -30 -22
--26 -25 -22 -9 12 7 16 7 31 0 48 -9 20 -11 21 -10 5 3 -43 0 -48 -16 -35 -20
-16 -19 29 3 53 9 11 12 18 7 15 -22 -13 -44 20 -37 54 3 9 42 -3 42 -13z m-38
--60 c-27 -10 -28 -20 -3 -38 11 -8 17 -20 14 -28 -3 -7 0 -13 6 -13 6 0 11 -9
-11 -20 0 -11 5 -20 10 -20 6 0 10 -15 10 -33 0 -31 -2 -33 -36 -35 l-35 -3 7
-61 c4 40 2 70 -6 90 -11 27 -11 32 6 45 10 7 23 11 28 7 5 -3 0 -9 -12 -13z
-m-32 -89 c-7 -17 -10 -48 -7 -70 7 -51 -8 -52 -19 -3 -12 56 -12 73 -3 67 5
--3 9 1 9 8 0 16 21 40 28 33 3 -2 -1 -18 -8 -35z"/>
-				</g>
-			</svg>
-			Advised Starter Builds
-		</td>
-		<td colspan="6"><span class="badge text-bg-secondary">These planners are for when you finish Hell to farm your next gear step, scroll down for complete planners.</span>
-		</td>
-	</tr>
-	</thead>
-
-
-	<!--Starter-->
-	<tbody class="table-group-divider table-light" id="tbodyStarter">
-
-	<!--Sorceress Starter-->
-	<tr class="table-sorc">
-		<td><span class="badge text-bg-secondary">Sorceress</span> Firewall</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=78&difficulty=3&quests=1&strength=93&dexterity=0&vitality=100&energy=207&coupling=1&skills=00000000000000000000000101010001010100200000000120010020000020000100&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Volcanic+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-success">Andariel</span>
-		</td>
-	</tr>
-	<tr class="table-sorc">
-		<td><span class="badge text-bg-secondary">Sorceress</span> Chain lightning</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=75&difficulty=3&quests=1&strength=93&dexterity=0&vitality=207&energy=85&coupling=1&skills=00000000000000000000002001010020200100002000000300000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Powered+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge text-bg-warning">Arcane Sanctuary</span>
-		</td>
-	</tr>
-	<tr class="table-sorc">
-		<td><span class="badge text-bg-secondary">Sorceress</span> Ice Barrage</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=74&difficulty=3&quests=1&strength=27&dexterity=0&vitality=268&energy=85&coupling=1&skills=20000001002000200000200001010000000100000000000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Glacial+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cold_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-		</td>
-	</tr>
-	<tr class="table-sorc">
-		<td><span class="badge text-bg-secondary">Sorceress</span> Meteor</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=76&difficulty=3&quests=1&strength=93&dexterity=0&vitality=212&energy=85&coupling=1&skills=00000000000000000000000001010000000100000000010101202001002020000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Volcanic+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-			<span class="badge text-bg-dark">Uber Tristam</span>
-		</td>
-	</tr>
-	<!--Druid Starter-->
-	<tr class="table-druid">
-		<td><span class="badge text-bg-secondary">Druid</span> Summons</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=80&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00000501000100000000000000000000000000000020012020010001010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+(Vigor)%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Bloodfist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Club+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge text-bg-info">Travincal</span>
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-			<span class="badge text-bg-dark">Uber Tristam</span>
-		</td>
-	</tr>
-	<tr class="table-druid">
-		<td>Bear - Shockwave</td>
-		<td>
-			<span class="badge text-bg-secondary">Druid</span>
-		</td>
-		<td colspan="5">
-			<span class="badge text-bg-info">Travincal</span>
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-	<tr class="table-druid">
-		<td>Wind Elemental</td>
-		<td>
-			<span class="badge text-bg-secondary">Druid</span>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-
-	<!--Assassin Starter-->
-	<tr class="table-assassin">
-		<td>Mind Blast</td>
-		<td>
-			<span class="badge text-bg-secondary">Assassin</span>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-			<span class="badge text-bg-dark">Uber Tristam</span>
-		</td>
-	</tr>
-	<tr class="table-assassin">
-		<td><span class="badge text-bg-secondary">Assassin</span> Blade Sentinel</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=78&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100000020000000002001010001010120002000000001000001000000010000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=none%2C0%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=none%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-			<span class="badge text-bg-dark">Uber Tristam</span>
-		</td>
-	</tr>
-	<tr class="table-assassin">
-		<td><span class="badge text-bg-secondary">Assassin</span> Chain Lightning Sentry</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=83&dexterity=60&vitality=267&energy=0&coupling=1&skills=0001000100000100010100050000000000000000200100200000200000002000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CWitherstring%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge text-bg-warning">Arcane Sanctuary</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-
-	<!--Barbarian Starter-->
-	<tr class="table-barbarian">
-		<td>Leap Attack</td>
-		<td>
-			<span class="badge text-bg-secondary">Barbarian</span>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-	<tr class="table-barbarian">
-		<td>Big Shouts + Find Item (A2 Offensive Merc)</td>
-		<td>
-			<span class="badge text-bg-secondary">Barbarian</span>
-		</td>
-		<td colspan="5">
-			<span class="badge text-bg-info">Travincal</span>
-		</td>
-	</tr>
-	<tr class="table-barbarian">
-		<td><span class="badge text-bg-secondary">Barbarian</span> Warcry</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=75&difficulty=3&quests=1&strength=11&dexterity=0&vitality=374&energy=0&coupling=1&skills=1600010100200100202000000000010101010000000101000100000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2Cnone%2Cnone%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Caster+Craft+Gloves%2C1%2Cnone&boots=none%2C0%2Cnone&belt=Caster+Craft+Belt%2C1%2Cnone%2C&amulet=Echoing+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge text-bg-info">Travincal</span>
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-		</td>
-	</tr>
-	<tr class="table-barbarian">
-		<td>Bleed Double Throw</td>
-		<td>
-			<span class="badge text-bg-secondary">Barbarian</span>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-
-	<!--Amazon Starter-->
-	<tr class="table-amazon">
-		<td><span class="badge text-bg-secondary">Amazon</span> Pure Summon (Decoy & Valk)</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=80&difficulty=3&quests=1&strength=95&dexterity=0&vitality=255&energy=60&coupling=1&skills=000000000000000000000103010100200120200100010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-			<span class="badge text-bg-dark">Uber Tristam</span>
-		</td>
-	</tr>
-	<tr class="table-amazon">
-		<td>Lightning Strike</td>
-		<td>
-			<span class="badge text-bg-secondary">Amazon</span>
-		</td>
-		<td colspan="5">
-			<span class="badge text-bg-warning">Arcane Sanctuary</span>
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-	<tr class="table-amazon">
-		<td><span class="badge text-bg-secondary">Amazon</span> Magic Arrow</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=75&difficulty=3&quests=1&strength=121&dexterity=53&vitality=211&energy=0&coupling=1&skills=000000000000000000002001200100010100000100200100002000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CNeophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Scepter%2CSpirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Archer%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Harmony+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-weapon%2C1%2C0&effect=Prayer-mercenary%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-
-	<!--Necromancer Starter-->
-	<tr class="table-necro">
-		<td><span class="badge text-bg-secondary">Necromancer</span> Clay Golems</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=75&difficulty=3&quests=1&strength=50&dexterity=0&vitality=335&energy=0&coupling=1&skills=000000202000200100000000000000000000000012000001000000010001000010&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2Cnone%2Cnone%2CSpirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2CAncient%27s+Pledge+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2Cnone%2Cnone%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Peasant+Crown%2C2%2Cnone%2C%2C%2C&armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Golemlord%27s+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Golemlord%27s+Tomb+Wand+of+the+Archmage%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Prayer-mercenary%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge text-bg-info">Travincal</span>
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-			<span class="badge text-bg-dark">Uber Tristam</span>
-		</td>
-	</tr>
-	<tr class="table-necro">
-		<td><span class="badge text-bg-secondary">Necromancer</span> Teeth / Bonespear</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=269&energy=50&coupling=1&skills=000000010000010900000000202000002000200000000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-	<tr class="table-necro">
-		<td><span class="badge text-bg-secondary">Necromancer</span> Dark Pact</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=70&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000101010001010100000100000000000000000001002010200000010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2Cnone%2Cnone%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=none%2C0%2Cnone%2C%2C%2C&armor=Smoke+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=none%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C">
-				<span class="badge rounded-pill text-bg-primary">Base Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-
-	<!--Paladin Starter-->
-	<tr class="table-paladin">
-		<td><span class="badge text-bg-secondary">Paladin</span> Holy Bolt / FOH</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=84&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000010001000101010000010001000100012000010001010120002020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Build Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-			<span class="badge text-bg-dark">Uber Tristam</span>
-		</td>
-	</tr>
-	<tr class="table-paladin">
-		<td>Smiter</td>
-		<td>
-			<span class="badge text-bg-secondary">Paladin</span>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-light">Key Farming</span>
-			<span class="badge text-bg-dark">Uber Tristam</span>
-		</td>
-	</tr>
-	<tr class="table-paladin">
-		<td><span class="badge text-bg-secondary">Paladin</span> Hammerdin</td>
-		<td>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=78&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000200001000100002020000000000000010100010020000100000100&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Sanctuary%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Stealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=none%2C0%2Cnone&boots=none%2C0%2Cnone&belt=none%2C0%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=none%2C0%2Cnone&ring2=none%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Build Planner</span></a>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-	<tr class="table-paladin">
-		<td>Vengeance</td>
-		<td>
-			<span class="badge text-bg-secondary">Paladin</span>
-		</td>
-		<td colspan="5">
-			<span class="badge rounded-pill text-bg-danger">Chaos</span>
-			<span class="badge text-bg-primary">Early Map</span>
-		</td>
-	</tr>
-	</tbody>
-
-
-	<thead id="theadSorceress">
-	<tr>
-		<td>
-			<svg xmlns="http://www.w3.org/2000/svg"
-			     width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000"
-			     preserveAspectRatio="xMidYMid meet">
-				<g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
-				   fill="#fff" stroke="none">
-					<path d="M156 296 c-9 -14 -27 -28 -41 -32 -14 -3 -25 -9 -25 -14 0 -13 37
--40 45 -33 4 5 5 0 2 -10 -4 -12 -3 -16 4 -11 7 4 9 -3 7 -17 -2 -15 2 -23 10
--21 6 1 11 -1 11 -5 -3 -21 3 -21 27 -1 l25 23 -21 17 c-11 9 -28 14 -35 11
--22 -8 -18 7 7 34 12 13 16 23 10 23 -14 0 -16 36 -2 45 6 4 7 -1 4 -12 -5
--16 -3 -15 11 2 15 19 16 19 10 -15 -3 -19 -10 -36 -15 -38 -6 -2 1 -18 15
--36 14 -18 22 -36 18 -39 -3 -4 -1 -7 6 -7 21 0 23 27 4 91 -22 74 -48 89 -77
-45z"/>
-					<path d="M5 290 c-3 -6 23 -38 59 -71 55 -52 64 -65 61 -90 -4 -35 -14 -51
--26 -44 -5 3 -6 -1 -3 -10 6 -15 -29 -57 -58 -68 -7 -3 12 -6 42 -6 35 0 50 2
-41 8 -11 7 -7 18 20 56 32 44 34 46 40 23 11 -39 10 -76 -3 -82 -7 -2 17 -4
-54 -4 74 1 77 8 24 57 -17 16 -24 31 -21 42 4 10 1 27 -5 39 l-11 20 -21 -20
--22 -20 -23 21 c-12 12 -20 25 -18 29 4 7 -108 130 -119 130 -2 0 -8 -5 -11
--10z m158 -166 c8 -9 -15 -44 -30 -44 -19 0 -3 30 16 31 12 0 12 2 -4 9 -15 6
--16 9 -4 9 9 1 18 -2 22 -5z m57 -19 c-5 -6 -8 -14 -5 -17 3 -2 -2 -5 -10 -5
--8 0 -12 4 -9 8 2 4 0 10 -6 14 -17 10 -2 24 20 18 15 -4 18 -9 10 -18z m25
--64 c25 -27 26 -30 7 -28 -11 0 -18 5 -15 10 3 4 -3 7 -13 5 -13 -2 -20 4 -22
-20 -5 30 9 28 43 -7z"/>
-				</g>
-			</svg>
-			Sorceress Builds
-		</td>
-		<td>Tier</td>
-
-		<td colspan="5">-</td>
-	</tr>
-	</thead>
-
-	<!--Sorceress-->
-	<tbody class="table-group-divider table-sorc" id="tbodySorceress">
-	<tr>
-		<td>Nova</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td class="align-middle" colspan="5"><a target="_blank"
-		                                        href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00010000060000000000002000202001002000002001000100000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2C%2C&armor=Steel+Carapace%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Constricting+Ring%2C0%2C%2B+Faster+Cast+Rate&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life">
-			<span class="badge rounded-pill text-bg-primary">End-game Gear</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=96&difficulty=3&quests=1&strength=106&dexterity=77&vitality=307&energy=0&coupling=1&skills=01010001010000000000002000202001002000002001000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2COndal%27s+Almighty%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CGoblin+Toe%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&gloves=Dracul%27s+Grasp%2C3%2C%2B+FBR&boots=Waterwalk%2C2%2C%2B+Mana+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+ICB%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Constricting+Ring%2C0%2C%2B+Mana+per+kill&ring2=Constricting+Ring%2C0%2C%2B+Mana+per+kill&weapon=Eschuta%27s+temper%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&offhand=Spirit+Ward%2C3%2C%2B+ICB+FBR%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Sparking+Grand+Charm+%2B+life">
-				<span class="badge rounded-pill text-bg-primary">End-game Gear</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=93&difficulty=3&quests=1&strength=200&dexterity=0&vitality=0&energy=275&coupling=1&skills=00000000000000000000002000202001000100202001000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormspire%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Dark+Abyss%2C3%2C%2B+CBF%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Mana+per+kill&boots=Silkweave%2C2%2C%2B+Mana+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Mana+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C0%2C0&effect=Defiance-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr">
-				<span class="badge rounded-pill text-bg-primary">Aspirational Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Charged Bolt</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002000200020012000082000000100000000000000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2C%2C&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cb%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life">
-			<span class="badge rounded-pill text-bg-primary">End-game Gear</span></a></td>
-	</tr>
-	<tr>
-		<td>Chain Lightning</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=81&difficulty=3&quests=1&strength=60&dexterity=0&vitality=335&energy=20&coupling=1&skills=00000000000000000000002000010020201100011800000100000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CRockfleece%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CCredendum&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Powered+Diadem%2C3%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Silkweave%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Powered+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Memory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-			<span class="badge rounded-pill text-bg-primary">Starter Gear</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002000010020202000082000000100000000000000000000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+Skill%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Thundergod%27s+Vigor%2C2%2C%2B+Faster+Cast+Rate%2C&amulet=Powered+Amulet+of+the+Apprentice%2C0%2C%2B+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Infinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+cl%2Bnova%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Lightning_Mastery%2C1%2C0&effect=Conviction-weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+fhr&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=%2B1+Sparking+Grand+Charm+%2B+life&charm=Annihilus+%2B2">
-				<span class="badge rounded-pill text-bg-primary">End-game Gear</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Frost Nova</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Frozen Orb</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Ice Barrage</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Blizzard</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Combustion</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Meteor</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=80&difficulty=3&quests=1&strength=60&dexterity=0&vitality=295&energy=55&coupling=1&skills=00000000000000000000000000010000000100000000010020202001002007000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CImp+Shank%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Volcanic+Diadem%2C3%2Cnone%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Volcanic+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Memory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0">
-			<span class="badge rounded-pill text-bg-primary">Starter Gear</span></a></td>
-	</tr>
-	<tr>
-		<td>Hydra</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Multishot Enchantress</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00200000010000002000200000010000000100000000011700000100200001000100&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CTemplar%27s+Might%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Caduceus%2CShattered+Wall+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CMagefist%2CImp+Shank%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Nightwing%27s+Veil%2C3%2C%2B+Skill%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magnus%27+Skin%2C2%2C%2B+Pierce&boots=Imp+Shank%2C2%2Cnone&belt=Razortail%2C2%2C%2B+Pierce%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&weapon=Widowmaker%2C3%2C%2B+IAS%2C%2C%2C%2C%2C%2C&offhand=Echo+Quiver+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Sharp+Arrows%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cold_Mastery%2C1%2C0&effect=Fire_Mastery%2C1%2C0&effect=Prayer-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Holy_Freeze-mercenary_offhand%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life&charm=%2B1+Chilling+Grand+Charm+%2B+life">
-			<span class="badge rounded-pill text-bg-primary">End-game Gear</span></a></td>
-	</tr>
-	</tbody>
-
-	<thead id="theadDruid">
-	<tr>
-		<td>
-			<svg xmlns="http://www.w3.org/2000/svg"
-			     width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000"
-			     preserveAspectRatio="xMidYMid meet">
-				<g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
-				   fill="#fff" stroke="none">
-					<path d="M204 302 c-12 -9 -36 -25 -53 -34 -17 -9 -31 -23 -31 -29 0 -7 3 -9
-7 -6 3 4 12 -1 20 -11 12 -15 12 -15 7 0 -6 18 22 38 53 38 14 0 12 -3 -7 -13
--14 -7 -26 -22 -28 -33 -2 -12 -16 -34 -32 -49 -30 -29 -55 -28 -85 1 -9 9
--15 11 -15 4 0 -6 -3 -9 -8 -6 -4 2 -13 -7 -19 -21 -11 -23 -10 -25 8 -20 17
-5 18 3 7 -11 -11 -14 -10 -15 6 -9 24 9 36 -7 36 -50 0 -20 -7 -36 -17 -42
--14 -8 -10 -10 23 -11 38 0 41 2 37 24 -3 13 0 27 6 31 17 10 43 -16 38 -37
--4 -15 1 -18 34 -18 l39 0 1 43 c1 23 4 53 8 67 6 23 8 23 14 6 4 -11 4 -22
--1 -25 -5 -3 -9 -25 -9 -48 0 -42 0 -43 34 -43 31 0 33 1 19 16 -16 15 -21 45
--17 91 1 13 -3 31 -8 41 -6 11 -6 24 -1 32 7 11 11 8 19 -12 6 -15 8 -36 6
--48 -3 -14 0 -20 8 -17 7 2 12 26 12 62 1 53 -1 60 -26 74 -20 11 -26 22 -25
-45 1 37 -27 46 -60 18z m50 -23 c-2 -17 -7 -36 -11 -42 -4 -7 -8 -18 -9 -25
--4 -25 -14 -26 -14 -1 0 14 5 30 12 37 9 9 9 12 0 12 -7 0 -12 11 -12 25 0 18
-5 25 19 25 15 0 18 -6 15 -31z m35 -48 c8 -5 15 -22 17 -38 2 -27 2 -27 -8 -5
--11 22 -38 31 -38 12 0 -5 -5 -10 -12 -10 -9 0 -9 3 -1 11 6 6 9 18 6 25 -6
-16 15 18 36 5z m-102 -75 c-2 -51 -3 -53 -24 -43 -13 6 -23 14 -23 19 0 5 4 7
-9 4 11 -7 24 21 29 62 1 6 4 12 6 12 2 0 4 -24 3 -54z m71 -8 c7 -7 12 -19 12
--27 -1 -13 -2 -13 -11 2 -15 25 -27 21 -34 -13 -9 -39 -21 -38 -29 2 -4 21 -2
-34 6 40 19 11 42 10 56 -4z m-156 -21 c7 -8 18 -12 24 -10 7 2 25 -8 40 -23
-16 -14 22 -22 13 -16 -8 6 -27 9 -42 7 -19 -4 -29 0 -37 15 -6 11 -15 18 -19
-16 -4 -3 -8 1 -8 9 0 19 11 19 29 2z"/>
-				</g>
-			</svg>
-			Druid Builds
-		</td>
-		<td>Tier</td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	</thead>
-
-	<!--Druid-->
-	<tbody class="table-group-divider table-druid" id="tbodyDruid">
-	<tr>
-		<td>Cold Elemental (Arctic Blast/Hurricane)</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Wind Elemental</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=90&difficulty=3&quests=1&strength=185&dexterity=80&vitality=130&energy=0&coupling=1&skills=00000420000120002000200000000000000000000000010100011100010100&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2CRal+Rune%2COrt+Rune&armor=Steel+Carapace%2C3%2C%2B+Skill%2C%2C%2C%2C%2CRal+Rune%2CCham+Rune&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+FHR%2C&amulet=Gaea%27s+Amulet%2C0%2C%2B+Faster+Cast+Rate%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Horizon%27s+Tornado%2C3%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Twilight%27s+Reflection%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CShael+Rune%2CShael+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Fire Elemental</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=97&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=01200101200101200120010000000000000000000001010101011201010101&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormlash%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CTrang-Oul%27s+Claws%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Ravenlore%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Mana+per+kill&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Siggard%27s+Staunch%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Gaea%27s+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Mana+per+kill&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Life+per+kill&weapon=Mang+Song%27s+Lesson%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life&charm=%2B1+Nature%27s+Grand+Charm+%2B+life">
-			<span class="badge rounded-pill text-bg-primary">End-game Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Wolf - Fire Claws</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Rabies</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000000000000000000002020002000200000000100200100010100010100&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CHowltusk%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CPus+Spitter%2CAetherwing%2CDracul%27s+Grasp%2CTancred%27s+Hobnails%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Jalal%27s+Mane%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Bramble+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Mana+per+kill&boots=Waterwalk%2C2%2C%2B+Faster+Run+Walk&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Faster+Run+Walk%2C&amulet=Mara%27s+Kaleidoscope%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Run%2FWalk&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Run%2FWalk&weapon=Plague+Bearer%2C2%2C%2B+Sockets+Weapon%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Stormshield%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Thorns-armor%2C1%2C0&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=%2B3%25+Infectious+Large+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Bear - Shockwave</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=00000001000120002000000015200001000000200000010100010100010100&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVampire+Gaze%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CWrath+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2Cnone%2CDracul%27s+Grasp%2CWar+Traveler%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2C%2C&armor=Ormus%27+Robes%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Soul+Drainer%2C3%2C%2B+Faster+Cast+Rate&boots=Merman%27s+Sprocket%2C3%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Communal+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Brimstone+Rain%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw&charm=%2B1+Spiritual+Grand+Charm+%2B+frw">
-			<span class="badge rounded-pill text-bg-primary">End-game Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Wolf - Fury</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Summon Druid</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=80&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00000501000100000000000000000000000000000020012020010001010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Bloodfist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Club+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Raven%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Starter Build</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=85&difficulty=3&quests=1&strength=80&dexterity=62&vitality=268&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Pelt+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Grizzly%2C1%2Cnone%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Mid Build</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=85&difficulty=3&quests=1&strength=135&dexterity=0&vitality=300&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010001010020&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Ravenlore%2C3%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Eaglehorn%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Conviction-mercenary_weapon%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Endgame - Raven</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=140&dexterity=0&vitality=295&energy=0&coupling=1&skills=00001001000100000000000000000000000000000020012020010011010020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Denmother%2C3%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Heart+of+the+Oak+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Flail%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+Ward%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Endgame - Bears</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=druid&level=95&difficulty=3&quests=1&strength=140&dexterity=0&vitality=295&energy=0&coupling=1&skills=00001001000100000000000000000000000000000011012020010020010020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Fenris%2C2%2C%2B+Skill%2C%2C%2C&armor=Arkaine%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Keeper%27s+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&weapon=Athena%27s+Wrath%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm&charm=%2B1+Trainer%27s+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Endgame - Spirit Wolf</span></a>
-		</td>
-	</tr>
-	</tbody>
-
-	<thead id="theadAssassin">
-	<tr>
-		<td>
-			<svg xmlns="http://www.w3.org/2000/svg"
-			     width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000"
-			     preserveAspectRatio="xMidYMid meet">
-				<g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
-				   fill="#fff" stroke="none">
-					<path d="M174 306 c-4 -9 -4 -25 -1 -36 3 -14 -1 -20 -17 -22 -11 -2 -21 -10
--22 -18 -2 -32 -5 -38 -34 -75 -30 -37 -34 -63 -11 -58 6 2 11 -3 12 -10 0 -6
-11 12 24 41 13 29 21 60 18 70 -4 11 2 8 17 -8 12 -14 27 -24 32 -22 5 1 7 -2
-3 -8 -5 -8 -11 -8 -20 0 -9 8 -17 0 -32 -35 -11 -25 -19 -59 -18 -75 1 -16 -2
--27 -6 -25 -4 3 -20 -2 -35 -10 -28 -15 -28 -15 36 -15 41 0 60 4 51 9 -17 11
--7 73 14 95 8 8 15 22 15 30 0 9 5 16 10 16 13 0 13 -27 -1 -36 -6 -4 -8 -20
--4 -40 3 -19 1 -43 -5 -54 -10 -19 -8 -20 37 -19 26 1 40 3 31 6 -11 3 -20 18
--23 41 -16 104 -17 99 12 120 23 16 25 22 15 35 -7 8 -11 21 -10 28 2 7 -6 15
--17 18 -14 4 -20 15 -20 36 0 24 -5 31 -23 33 -13 2 -25 -3 -28 -12z m33 -18
-c4 -7 6 -21 5 -30 -2 -13 3 -18 19 -18 18 0 19 -2 9 -15 -11 -14 -15 -14 -30
-2 -10 10 -16 20 -14 22 2 2 -1 10 -7 18 -9 10 -8 13 2 13 11 0 11 2 -1 10 -9
-6 -10 10 -3 10 6 0 15 -6 20 -12z m-18 -57 c10 -7 11 -13 2 -27 -8 -15 -11
--16 -12 -4 -1 8 -1 18 0 22 0 4 -5 5 -13 2 -8 -3 -17 -1 -21 5 -8 13 24 14 44
-2z m81 -42 c0 -5 -11 -8 -24 -7 -20 2 -22 5 -13 20 8 12 15 14 24 6 7 -6 13
--14 13 -19z"/>
-				</g>
-			</svg>
-			Assassin Builds
-		</td>
-		<td>Tier</td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	</thead>
-
-
-	<!--Assassin-->
-	<tbody class="table-group-divider table-assassin" id="tbodyAssassin">
-	<tr>
-		<td>Chain Lightning Sentry</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0000000000000000000101030004010000000000200100200000200000002000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CDuskdeep%2CRockfleece%2CPus+Spitter%2CRamfodder%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem%2C3%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lightning+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0">
-			<span class="badge rounded-pill text-bg-primary">Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Wake of Fire</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=81&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0000000000000000000101030006010000000000202000002000002000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CDuskdeep%2CRockfleece%2CPus+Spitter%2CRamfodder%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem%2C3%2Cnone%2C%2C%2C&armor=Skullder%27s+Ire%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Cunning+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0">
-			<span class="badge rounded-pill text-bg-primary">Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=95&difficulty=3&quests=1&strength=40&dexterity=0&vitality=330&energy=0&coupling=1&skills=0001000100000100200101010015010001000000200001002001002000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CVampire+Gaze%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CMarrowwalk%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Assassin%2C3%2C%2B+CBF%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=War+Traveler%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Metalgrid%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Run%2FWalk&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Run%2FWalk&weapon=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor&offhand=Fire+Cunning+Greater+Talons+of+Quickness%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=Annihilus+%2B2">
-				<span class="badge rounded-pill text-bg-primary">Claw End-game Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=97&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0001000100000100200101010002010001000015200001002001002000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CHeavenly+Garb%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Cunning+Diadem+of+the+Magus%2C3%2C%2B+Skill%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Chains+of+Honor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+ICB&boots=Marrowwalk%2C3%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+PDR%2C&amulet=Cunning+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Damage+Reduction&ring2=Wisp+Projector%2C0%2C%2B+Damage+Reduction&weapon=Ghostflame%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Gerke%27s+Sanctuary%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Blessed_Aim-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=%2B1+Entrapping+Grand+Charm+%2B+frw&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Entrapping+Grand+Charm+%2B+fhr&charm=%2B3%25+Inferno+Large+Charm+of+Balance">
-				<span class="badge rounded-pill text-bg-primary">Dagger End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Summon Sin (Martial Arts)</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5"><span class="badge rounded-pill text-bg-secondary">Requires Skill Charms</span></td>
-	</tr>
-	<tr>
-		<td>Cobra Sin</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=88&difficulty=3&quests=1&strength=150&dexterity=68&vitality=232&energy=0&coupling=1&skills=0101000120000100012001030005010120002000000001000001000000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CStormspire%2Cnone%2CLava+Gout%2CImp+Shank%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Steel+Carapace%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Kenshi%27s+Gloves+of+Quickness%2C1%2C%2B+All+Resistances&boots=Imp+Shank%2C2%2C%2B+FBR&belt=Siggard%27s+Staunch%2C3%2C%2B+PDR%2C&amulet=Blood+Craft+-+Assassin%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Attack+Rating&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Attack+Rating&weapon=Jade+Talon%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Whispering+Mirage%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+fhr&charm=%2B1+Shogukusha%27s+Grand+Charm+%2B+life&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=Ruby+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance">
-				<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Phoenix Strike</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=77&difficulty=3&quests=1&strength=0&dexterity=0&vitality=395&energy=0&coupling=1&skills=0100200001200020000100010001000000000000000001000001000000010020&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2CPus+Spitter%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2Cnone%2C%2C%2C&armor=Stone+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Kenshi%27s+Gloves+of+Giant%2C1%2Cnone&boots=Merman%27s+Sprocket%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Blood+Craft+-+Assassin%2C0%2Cnone%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2Cnone&ring2=Dual+Leech+Ring%2C0%2Cnone&weapon=Bartuc%27s+Cut+Throat%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Bartuc%27s+Cut+Throat%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Shogukusha%27s+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Starter Build Planner</span></a>
-		</td>
-
-	</tr>
-	<tr>
-		<td>Dragon Tail (Fire Kick) Stalker's Cull</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Dragon Tail (Fire Kick) Astreons + Phoenix RW</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=91&difficulty=3&quests=1&strength=140&dexterity=130&vitality=195&energy=0&coupling=1&skills=0020000100002000200101200001010001000002000001000001000000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CMarrowwalk%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Fortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+Deadly+Strike&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+x+Enhanced+Damage%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&ring2=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&weapon=Astreon%27s+Iron+Ward%2C3%2C%2B+Sockets+Weapon%2C%2C%2CLo+Rune%2CLo+Rune%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Phoenix+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Monarch%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Redemption-offhand%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance">
-				<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Blade Fury</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-
-		</td>
-	</tr>
-	<tr>
-		<td>Blade Sentinel (Phys)</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Blade Sentinel (Venom)</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Summon Sin (Mind Blast)</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">
-			<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-			   href="https://www.google.com/url?q=https://tinyurl.com/s11mindblast&amp;sa=D&amp;source=editors&amp;ust=1757267248684136&amp;usg=AOvVaw1PC2217VwizNE0QTZQMnft"
-			   rel="noreferrer" target="_blank">Build Guide</a>
-		</td>
-	</tr>
-	<tr>
-		<td>Physical Blade Dance (Chaos - Phys Dmg Focus)</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">
-			<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-			   href="https://www.google.com/url?q=https://tinyurl.com/s8bladedance&amp;sa=D&amp;source=editors&amp;ust=1757267248684611&amp;usg=AOvVaw3_iB8yjpdDyxVgPEqWoEHv"
-			   rel="noreferrer" target="_blank">Generic WWsin Build Guide</a>
-		</td>
-	</tr>
-	<tr>
-		<td>Poison Blade Dance (Chaos - Venom Dmg Focus)</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=80&difficulty=3&quests=1&strength=84&dexterity=30&vitality=296&energy=0&coupling=1&skills=0100000020000000002000200006000100002000000001000001000000010000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVampire+Gaze%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDemon+Machine%2CDoom%27s+Finger%2CBloodfist%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Natalya%27s+Totem%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Natalya%27s+Shadow%2C3%2C%2B+Skill%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Venom+Grip%2C2%2C%2B+ICB&boots=Natalya%27s+Soul%2C2%2C%2B+Faster+Run+Walk&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Faster+Run+Walk%2C&amulet=Blood+Craft+-+Assassin%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&ring2=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&weapon=Natalya%27s+Mark%2C3%2C%2B+Psn+Pierce%2C%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&offhand=Chaos+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Fist%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=%2B1+Mentalist%27s+Grand+Charm+%2B+frw&charm=Ruby+Small+Charm+of+Vita&charm=Ruby+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia&charm=Fine+Small+Charm+of+Inertia">
-				<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-			<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-			   href="https://www.google.com/url?q=https://tinyurl.com/s8bladedance&amp;sa=D&amp;source=editors&amp;ust=1757267248684884&amp;usg=AOvVaw361TEiP3HC1zKq2oOD4LHs"
-			   rel="noreferrer" target="_blank">Generic WWsin Build Guide</a>
-			<span class="badge rounded-pill text-bg-secondary">Must gear swap pre-buff</span>
-		</td>
-	</tr>
-	</tbody>
-
-	<thead id="theadBarbarian">
-	<tr>
-		<td>
-			<svg xmlns="http://www.w3.org/2000/svg"
-			     width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000"
-			     preserveAspectRatio="xMidYMid meet">
-				<g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
-				   fill="#fff" stroke="none">
-					<path d="M132 308 c-7 -7 -12 -22 -12 -34 0 -17 -5 -20 -23 -17 -25 5 -45 -12
--52 -43 -2 -11 -9 -34 -14 -53 -12 -39 -8 -49 23 -61 30 -11 27 -41 -9 -74
-l-28 -26 63 0 63 0 -6 39 c-6 45 7 76 18 42 3 -12 4 -35 0 -51 l-7 -30 54 1
-c29 0 47 3 40 6 -9 3 -7 12 8 30 21 27 27 59 10 48 -6 -4 -19 -1 -28 6 -15 12
--14 11 1 -7 17 -20 17 -23 2 -38 -23 -22 -23 -21 -21 24 1 22 -1 40 -6 40 -4
-0 -8 14 -8 31 0 26 3 29 14 20 8 -7 12 -21 9 -31 -7 -25 21 -37 43 -19 8 7 13
-21 11 31 -3 10 -2 16 3 13 10 -6 45 33 37 42 -4 3 -16 -2 -27 -12 -19 -17 -20
--17 -28 6 -5 13 -7 29 -5 36 6 16 -33 36 -57 28 -10 -3 -22 0 -26 6 -4 8 -3 9
-4 5 8 -5 12 1 12 16 0 17 3 19 9 9 5 -8 16 -11 27 -7 16 6 16 7 -2 21 -23 18
--76 19 -92 3z m43 -8 c4 -6 1 -17 -5 -25 -10 -12 -10 -18 -1 -29 10 -12 8 -17
--11 -28 -13 -7 -33 -13 -45 -15 -21 -2 -21 -1 -5 18 17 19 38 27 27 9 -3 -6 1
--7 9 -4 14 5 13 9 -1 30 -14 22 -14 24 3 25 11 0 14 3 7 6 -7 2 -13 9 -13 14
-0 12 27 11 35 -1z m-78 -65 c0 -14 -26 -30 -35 -21 -2 3 -2 12 1 21 8 19 34
-20 34 0z m118 -2 c-19 -15 -19 -15 10 -9 22 5 26 4 15 -4 -18 -12 -60 -13 -60
--2 0 13 23 32 40 32 12 -1 11 -4 -5 -17z m34 -46 c-1 -7 1 -20 6 -30 9 -21 -8
--46 -19 -28 -4 6 -2 11 4 11 6 0 -1 11 -16 25 -21 19 -30 22 -40 14 -8 -6 -21
--9 -29 -5 -9 3 -15 0 -15 -9 0 -8 -7 -15 -15 -15 -8 0 -15 7 -15 16 0 14 -3
-14 -16 4 -12 -11 -18 -10 -32 5 -9 10 -12 15 -5 11 6 -3 14 0 16 6 4 9 8 9 14
-3 13 -16 28 -16 90 -1 60 14 75 12 72 -7z m-79 -31 c0 -8 -68 -46 -81 -45 -11
-0 -11 2 -1 6 9 3 10 9 3 17 -8 10 -4 11 18 8 16 -2 32 1 35 7 7 11 26 16 26 7z
-m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
--16 0 -29 27 -20 41 11 18 37 10 31 -11z m-74 -67 c10 -10 -13 -33 -34 -33
--10 0 -20 4 -23 9 -4 5 5 8 19 6 14 -1 28 2 32 8 3 6 1 7 -5 3 -6 -3 -13 -2
--17 4 -7 11 18 14 28 3z"/>
-					<path d="M24 211 c4 -6 1 -14 -7 -16 -7 -3 -13 -15 -12 -25 2 -33 10 -31 21 6
-8 23 8 37 1 41 -6 3 -7 1 -3 -6z"/>
-				</g>
-			</svg>
-			Barbarian Builds
-		</td>
-		<td>Tier</td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	</thead>
-
-	<!--Barbarian-->
-	<tbody class="table-group-divider table-barbarian" id="tbodyBarbarian">
-	<tr>
-		<td>Warcry</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">-
-		</td>
-	</tr>
-	<tr>
-		<td>Travbarb</td>
-		<td><span class="badge rounded-pill text-bg-secondary">Travincal</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=90&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0101010120200900012000000000010120050000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Blessed+Aim%29%2CCrown+of+Thieves%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CArioc%27s+Needle%2Cnone%2CLaying+of+Hands%2CInfernostride%2CGoldwrap&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Crown+of+Thieves%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Chance+Guards%2C1%2C%2B+Faster+Cast+Rate&boots=Infernostride%2C2%2C%2B+Faster+Run+Walk&belt=Goldwrap%2C1%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Barbarian%2C0%2C%2B+Faster+Run+Walk%2C&ring1=Dwarf+Star%2C0%2C%2B+Faster+Cast+Rate&ring2=Dwarf+Star%2C0%2C%2B+Faster+Cast+Rate&weapon=Blade+of+Ali+Baba%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Blade+of+Ali+Baba%2C2%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Blessed_Aim-mercenary%2C1%2C0&charm=Gheed%27s+Fortune&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed&charm=Lucky+Grand+Charm+of+Greed">
-			<span class="badge rounded-pill text-bg-primary">End-game Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Fire Whirlwind (2x Flamebellow)</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100000100000100002020000100010120051601010000000000002001&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+All+Resistances&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+Faster+Run+Walk%2C&amulet=The+Rising+Sun%2C0%2C%2B+Faster+Run+Walk%2C&ring1=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&ring2=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&weapon=Flamebellow%2C3%2C%2B+Fire+Pierce%2C%2C%2C%2C%2C%2C&offhand=Flamebellow%2C3%2C%2B+Fire+Pierce%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Holy_Fire-armor%2C0%2C0&effect=Holy_Fire-weapon%2C0%2C0&effect=Holy_Fire-combined%2C1%2C0&effect=Holy_Fire-offhand%2C0%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm">
-			<span class="badge rounded-pill text-bg-primary">End-game Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Whirlwind (2-H)</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">
-			<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-			   href="https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248685787&amp;usg=AOvVaw3TaX-_ZjjfElauMuEMEOcp"
-			   rel="noreferrer" target="_blank">Build Guide</a>
-			<span class="badge rounded-pill text-bg-secondary">4 range adder weapon only</span>
-			<span class="badge rounded-pill text-bg-secondary">must weapon swap for frenzy</span>
-		</td>
-	</tr>
-	<tr>
-		<td>Whirlwind (Dual Wield)</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100010100000120012001002000010110010801010000000000002001&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Halaberd%27s+Reign%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Tyrael%27s+Might%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Soul+Drainer%2C3%2C%2B+All+Resistances&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=String+of+Ears%2C2%2C%2B+Faster+Run+Walk%2C&amulet=Atma%27s+Scarab%2C0%2C%2B+2+All+Skills%2C&ring1=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&ring2=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&weapon=The+Grandfather%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=Schaefer%27s+Hammer%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Fanatic+Grand+Charm+%2B+frw&charm=%2B1+Expert%27s+Grand+Charm+%2B+frw">
-				<span class="badge rounded-pill text-bg-primary">End-game Planner</span></a>
-			<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-			   href="https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248686138&amp;usg=AOvVaw3p5jaWKspgdKbaJvQ0Yzy3"
-			   rel="noreferrer" target="_blank">Build Guide</a>
-		</td>
-	</tr>
-	<tr>
-		<td>Leap Attack (Physical)</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">
-			<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-			   href="https://www.google.com/url?q=https://discord.com/channels/701658302085595158/776859497279782922/1237778531690483814&amp;sa=D&amp;source=editors&amp;ust=1757267248686379&amp;usg=AOvVaw1YtzVDFBx7zRYXXLb7fwLe"
-			   rel="noreferrer" target="_blank">Build Guide</a>
-			<span class="badge rounded-pill text-bg-secondary">Eth Obedience or Reapers toll as starter weapon</span>
-		</td>
-	</tr>
-	<tr>
-		<td>Leap Attack (Ele Proc)</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">
-
-			<span class="badge rounded-pill text-bg-secondary">Stormspire | Rapture | Destruction</span>
-			<span class="badge rounded-pill text-bg-secondary">Infinity Merc</span>
-			<span class="badge rounded-pill text-bg-secondary">Ele % LC</span>
-		</td>
-	</tr>
-	<tr>
-		<td>Double Throw</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=91&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=0100010100000101010100002020010101010100000000200000000001&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CDuskdeep%2CLeviathan%2CCranebeak%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Demonhorn%27s+Edge%2C3%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2Cnone&boots=Gore+Rider%2C2%2Cnone&belt=Nosferatu%27s+Coil%2C3%2Cnone%2C&amulet=Highlord%27s+Wrath%2C0%2Cnone%2C&ring1=Raven+Frost%2C0%2Cnone&ring2=Bul-Kathos%27+Death+Band%2C0%2Cnone&weapon=Lacerator%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2CRuby+Jewel+of+Fervor&offhand=Lacerator%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=%2B1+Fanatic+Grand+Charm+%2B+fhr&charm=Lucky+Grand+Charm+of+Greed&charm=Sharp+Grand+Charm+of+Quality&charm=%2B1+Fanatic+Grand+Charm&charm=%2B1+Fanatic+Grand+Charm&charm=%2B1+Fanatic+Grand+Charm&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck&charm=Shimmering+Small+Charm+of+Good+Luck">
-				<span class="badge rounded-pill text-bg-primary">Starter Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=barbarian&level=91&difficulty=3&quests=1&strength=180&dexterity=170&vitality=115&energy=0&coupling=1&skills=0100010100000101012000000111010101012000000000200000000020&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CAndariel%27s+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CBlacktongue%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Steelrend%2C3%2C%2B+Deadly+Strike&boots=Gore+Rider%2C2%2C%2B+PDR&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+CBF%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=Constricting+Ring%2C0%2Cnone&weapon=Wraith+Flight%2C3%2C%2B+ED+Deadly%2C%2C%2C%2C%2Cvs+Demon+Jewel%2Cvs+Demon+Jewel&offhand=Lacerator%2C3%2C%2B+IAS+Enhanced+Damage%2C%2C%2C%2C%2CRuby+Jewel+of+Fervor%2CCham+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Iron_Skin%2C1%2C0&effect=Natural_Resistance%2C1%2C0&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=%2B1+Expert%27s+Grand+Charm+%2B+fhr&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita">
-				<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-			<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-			   href="https://www.google.com/url?q=https://docs.google.com/document/d/1pL10s0YlRA5gLcFFDWh1oKYb-32a4skQkmsikMsT2sc/edit?tab%3Dt.0%23heading%3Dh.7ng7k3wkxynr&amp;sa=D&amp;source=editors&amp;ust=1757267248686857&amp;usg=AOvVaw39MsO3qC51YEI_uUeKs5R8"
-			   rel="noreferrer" target="_blank">Build Guide</a>
-		</td>
-	</tr>
-	</tbody>
-
-	<thead id="theadAmazon">
-	<tr>
-		<td>
-			<svg xmlns="http://www.w3.org/2000/svg"
-			     width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000"
-			     preserveAspectRatio="xMidYMid meet">
-				<g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
-				   fill="#fff" stroke="none">
-					<path d="M213 305 c-3 -9 -3 -24 0 -35 3 -11 0 -20 -5 -20 -6 0 -25 -16 -42
--36 l-31 -36 -42 46 c-23 25 -39 46 -35 46 4 1 -6 8 -21 16 -36 20 -43 13 -23
--23 8 -15 15 -24 16 -20 0 15 158 -148 165 -171 3 -12 11 -19 17 -16 7 4 8 2
-4 -5 -4 -6 -12 -8 -18 -5 -6 4 -8 -1 -3 -15 4 -13 2 -21 -5 -21 -6 0 -8 5 -5
-10 8 12 -8 13 -21 1 -5 -5 -18 -11 -29 -14 -11 -3 12 -5 50 -6 39 0 65 3 58 7
--7 4 -10 27 -8 57 1 28 3 61 4 74 1 30 18 17 24 -19 3 -14 8 -38 11 -55 6 -27
-5 -27 -4 -7 -5 13 -15 20 -20 17 -8 -5 -7 -12 2 -22 7 -9 12 -18 11 -20 -2 -1
--3 -10 -3 -18 0 -10 10 -15 31 -15 31 0 31 0 15 25 -9 13 -18 37 -20 52 -2 16
--8 41 -15 56 -14 35 -14 60 -1 52 12 -8 13 5 1 24 -8 12 -12 12 -25 2 -12 -11
--16 -11 -16 -1 0 10 -3 10 -15 0 -10 -9 -15 -9 -15 -1 0 11 13 15 38 12 6 -1
-12 3 12 9 0 5 -5 10 -11 10 -5 0 -8 4 -4 9 3 5 1 12 -5 16 -16 10 -11 23 8 20
-9 -1 16 -9 14 -19 -2 -9 7 -26 18 -38 14 -15 19 -31 15 -45 -3 -12 -1 -25 5
--28 5 -3 10 -12 10 -18 0 -7 -4 -6 -11 3 -9 12 -10 12 -7 1 8 -29 28 -23 28 7
-0 37 -26 102 -41 102 -7 0 -8 7 -4 18 4 9 8 23 8 30 0 15 12 5 12 -10 0 -6 6
--13 13 -16 10 -3 10 2 1 21 -8 18 -19 24 -45 25 -23 1 -37 -4 -41 -13z m-14
--127 c0 -7 -4 -21 -8 -31 -6 -17 -8 -17 -20 -3 -11 13 -11 19 -1 31 15 18 30
-20 29 3z"/>
-				</g>
-			</svg>
-			Amazon Builds
-		</td>
-		<td>Tier</td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	</thead>
-
-	<!--Amazon-->
-	<tbody class="table-group-divider table-amazon" id="tbodyAmazon">
-	<tr>
-		<td>Lightning Fury</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=96&difficulty=3&quests=1&strength=0&dexterity=106&vitality=384&energy=0&coupling=1&skills=012001002000010000200101011000011000002000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+CBF%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Pierce%2C&amulet=Blood+Craft+-+Amazon%2C0%2C%2B+2+All+Skills%2C&ring1=Constricting+Ring%2C0%2C%2B+Life+per+kill&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Mana+per+kill&weapon=Thunderstroke%2C3%2C%2B+IAS+Crushing+Blow%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&offhand=Lidless+Wall%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor%2CLPK%2FMPK+Jewel&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B3%25+Conduit+Large+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=Shimmering+Small+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Balance">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Lightning Strike</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Power Strike</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Plague Javelin</td>
-		<td><span class="badge rounded-pill text-bg-danger">Bad</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Freezing Arrow</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Cold Arrow</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=90&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000101010100001700002020200000200000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CCrown+of+Ages%2CFortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CAbyssal+Ward%2CLaying+of+Hands%2CMarrowwalk%2CVerdungo%27s+Hearty+Cord&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Nightwing%27s+Veil%2C3%2Cnone%2C%2C%2C&armor=Silks+of+the+Victor%2C1%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Archer%27s+of+Quickness%2C1%2Cnone&boots=Merman%27s+Sprocket%2C3%2Cnone&belt=Snowclash%2C2%2Cnone%2C&amulet=Blood+Craft+-+Amazon%2C0%2Cnone%2C&ring1=The+Stone+of+Jordan%2C0%2Cnone&ring2=The+Stone+of+Jordan%2C0%2Cnone&weapon=Pus+Spitter%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Frozen+Sorrow%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Numbing+Large+Charm&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia&charm=Shimmering+Small+Charm+of+Inertia">
-			<span class="badge rounded-pill text-bg-primary">Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Lighting Arrow</td>
-		<td><span class="badge rounded-pill text-bg-danger">Bad</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Fire Arrow</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Explosive Arrow</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-</td>
-
-	</tr>
-	<tr>
-		<td>Jab/Fend</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=95&difficulty=3&quests=1&strength=44&dexterity=77&vitality=364&energy=0&coupling=1&skills=200000200000002000000120010100200200000100000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CGiant+Skull%2CBlack+Hades%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CAnvilguard+Strap%2CLava+Gout%2CGore+Rider%2CRazortail&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CVex+Rune%2CVex+Rune%2CVex+Rune&armor=Shaftstop%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Increased+Attack+Speed&boots=Gore+Rider%2C2%2C%2B+PDR&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Metalgrid%2C0%2C%2B+CBF%2C&ring1=Bul-Kathos%27+Death+Band%2C0%2C%2B+Damage+Reduction&ring2=Raven+Frost%2C0%2C%2B+Damage+Reduction&weapon=Stoneraven%2C3%2C%2B+Sockets+Weapon%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Multiple Shot</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5">
-			<span
-					style="text-decoration:underline;text-decoration-skip-ink:none;-webkit-text-decoration-skip:none;color:#ff6d01;"><a
-					class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-					href="https://www.youtube.com/watch?v=HzPLfKwjhqA"
-					rel="noreferrer" target="_blank">S12 Video</a></span>
-			<span style="text-decoration:underline;text-decoration-skip-ink:none;-webkit-text-decoration-skip:none;color:#ff6d01;"><a
-					class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-					href="https://docs.google.com/spreadsheets/d/1Mcmwpn5CkyR7BdEOlj1BuQIE-PxYHXtax3WywsBKeL8/edit?gid=944046235#gid=944046235"
-					rel="noreferrer" target="_blank">Spreadsheet</a></span>
-		</td>
-	</tr>
-	<tr>
-		<td>Strafe (Demon Machine)</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=91&difficulty=3&quests=1&strength=55&dexterity=270&vitality=140&energy=0&coupling=1&skills=000000000000000000000120010500202000021000010100000100200000&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CAndariel%27s+Visage%2CFortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Berserker+Axe%2Cnone%2CLaying+of+Hands%2CGore+Rider%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Valkyrie+Wing%2C2%2C%2B+Sockets+Helm%2C%2C%2CRuby+Jewel&armor=Fortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Laying+of+Hands%2C3%2Cnone&boots=Goblin+Toe%2C1%2Cnone&belt=Razortail%2C2%2Cnone%2C&amulet=Atma%27s+Scarab%2C0%2Cnone%2C&ring1=Carrion+Wind%2C0%2Cnone&ring2=Raven+Frost%2C0%2Cnone&weapon=Demon+Machine%2C2%2C%2B+Sockets+Weapon%2C%2C%2CRuby+Jewel%2CRuby+Jewel%2CRuby+Jewel%2CScintillating+Jewel+of+Fervor&offhand=Shatterhead%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Gheed%27s+Fortune&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Sharp+Grand+Charm&charm=Ruby+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Amber+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Serpent%27s+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita">
-			<span class="badge rounded-pill text-bg-primary">Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=96&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120011100202000001100010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CVeil+of+Steel%2CTemplar%27s+Might%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CShatterhead%2CLaying+of+Hands%2CGoblin+Toe%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2CScintillating+Jewel+of+Freedom%2CScintillating+Jewel+of+Freedom%2CRuby+Jewel+of+Carnage&armor=Tyrael%27s+Might%2C3%2C%2B+Faster+Run+Walk%2C%2C%2C%2C%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage&gloves=Soul+Drainer%2C3%2C%2B+Enhanced+Damage&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=Razortail%2C2%2C%2B+Faster+Run+Walk%2C&amulet=Atma%27s+Scarab%2C0%2C%2B+Enhanced+Damage%2C&ring1=Carrion+Wind%2C0%2C%2B+Faster+Run%2FWalk&ring2=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&weapon=Demon+Machine%2C2%2C%2B+Sockets+Weapon%2C%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage%2CRuby+Jewel+of+Carnage&offhand=Shatterhead%2C0%2C%2B+Enhanced+Damage%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Inertia&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Balance&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Gheed%27s+Fortune&charm=Shimmering+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Balance&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita&charm=Fine+Small+Charm+of+Vita">
-				<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Magic Arrow</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Summon Zon</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000102010000200120200500010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CCow+King%27s+Horns%2CCow+King%27s+Hide%2CThe+Iron+Jang+Bong%2Cnone%2CMagefist%2CImp+Shank%2CLenymo&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Tarnhelm%2C1%2Cnone%2C%2C%2C&armor=Peace+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Goldwrap%2C1%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Dual+Leech+Ring%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Loyalty+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Starter Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=80&difficulty=3&quests=1&strength=95&dexterity=0&vitality=255&energy=60&coupling=1&skills=000000000000000000000103010100200120200100010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CMemory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2CMagefist%2CRite+of+Passage%2CGloom%27s+Trap&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Lore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2C1%2Cnone%2C%2C%2C&armor=Hustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Manald+Heal%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Shield%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C">
-				<span class="badge rounded-pill text-bg-primary">Alt Starter Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=85&difficulty=3&quests=1&strength=95&dexterity=0&vitality=280&energy=60&coupling=1&skills=000000000000000000000105010100200120200400010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CRockstopper%2CRockfleece%2CWitchwild+String%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Valkyrie+Wing%2C2%2C%2B+Sockets+Helm%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Marrowwalk%2C3%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Passion+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Crystal+Sword%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Lidless+Wall%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Mid Solo Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=93&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000101010100200120201600010100000100200000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2CSkystrike%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Athlete%27s+Diadem+of+the+Magus%2C3%2Cnone%2C%2C%2C&armor=Peace+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Nightsmoke%2C1%2Cnone%2C&amulet=Athlete%27s+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Raven+Frost%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Loyalty+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&charm=Annihilus&charm=Hellfire+Torch&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm&charm=%2B1+Acrobat%27s+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=99&difficulty=3&quests=1&strength=95&dexterity=0&vitality=280&energy=60&coupling=1&skills=011100000000000000000101010100200120201000010100000100200000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2COndal%27s+Almighty%2CTemplar%27s+Might%2CBeast+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2COccultist%2CMarrowwalk%2CArachnid+Mesh&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Athlete%27s+Diadem%2C3%2C%2B+Skill%2C%2C%2C&armor=Spirit+Shroud%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Athlete%27s+Gloves+of+Quickness%2C1%2Cnone&boots=Infernostride%2C2%2Cnone&belt=Arachnid+Mesh%2C3%2Cnone%2C&amulet=Athlete%27s+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2Cnone&ring2=The+Stone+of+Jordan%2C0%2Cnone&weapon=Mist+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Colossus+Crossbow%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Athlete%27s+Quiver%2C0%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary_armor%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&effect=Concentration-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Arcane+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Acrobat%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw&charm=%2B1+Fletcher%27s+Grand+Charm+%2B+frw">
-				<span class="badge rounded-pill text-bg-primary">End-Game Rich Build Planner</span></a>
-		</td>
-
-	</tr>
-	<tr>
-		<td>Pure Summon</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">
-			<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2"
-			   href="https://www.google.com/url?q=https://docs.google.com/spreadsheets/d/1Mcmwpn5CkyR7BdEOlj1BuQIE-PxYHXtax3WywsBKeL8/edit?gid%3D1318666241%23gid%3D1318666241&amp;sa=D&amp;source=editors&amp;ust=1757267248689986&amp;usg=AOvVaw2YhawQKfIMu0mOzznuuSii"
-			   rel="noreferrer" target="_blank">Build Guide (Solo leveling tab)</a>
-			<span class="badge rounded-pill text-bg-secondary">Loyalty RW & Amp merc</span>
-		</td>
-	</tr>
-	</tbody>
-
-	<thead id="theadNecromancer">
-	<tr>
-		<td>
-			<svg xmlns="http://www.w3.org/2000/svg"
-			     width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000"
-			     preserveAspectRatio="xMidYMid meet">
-				<g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
-				   fill="#fff" stroke="none">
-					<path d="M25 295 c-24 -23 -36 -73 -15 -60 5 3 7 0 4 -8 -3 -8 1 -19 9 -25 12
--10 13 -8 10 12 -7 34 14 68 37 61 23 -7 36 11 20 30 -18 21 -37 18 -65 -10z"/>
-					<path d="M200 305 c-7 -8 -10 -24 -7 -35 3 -12 0 -20 -7 -20 -7 0 -17 -5 -24
--12 -9 -9 -8 -16 5 -32 10 -12 11 -15 3 -9 -9 9 -17 9 -26 2 -13 -11 -14 6 -2
-27 4 6 -3 21 -16 33 -15 15 -26 19 -31 12 -6 -10 0 -15 17 -12 4 0 5 -6 2 -14
--4 -8 -3 -26 0 -39 5 -19 12 -24 34 -23 20 2 26 -2 22 -13 -4 -14 -3 -73 3
--114 1 -12 -10 -25 -33 -37 l-35 -19 55 0 55 0 -2 53 c-2 75 -2 77 -12 77 -4
-0 -6 -12 -3 -26 3 -17 1 -25 -5 -21 -16 10 -22 66 -7 60 9 -3 12 2 9 16 -3 15
-0 19 8 14 9 -5 9 -3 0 8 -17 20 -16 27 1 54 10 15 12 26 6 30 -15 10 -12 35 6
-42 9 3 20 0 24 -8 13 -20 0 -32 -17 -17 -15 12 -15 11 -3 -9 11 -16 11 -27 3
--45 -7 -16 -8 -30 -1 -41 6 -11 5 -17 -2 -17 -6 0 -8 -4 -5 -10 10 -17 21 -11
-34 16 10 22 9 28 -5 39 -14 10 -15 13 -3 20 8 5 11 5 7 0 -5 -5 1 -14 12 -22
-11 -8 20 -22 20 -31 0 -15 -2 -15 -10 -2 -8 13 -10 13 -10 -2 0 -9 -9 -23 -19
--30 -14 -10 -17 -18 -10 -28 13 -21 11 -43 -3 -34 -8 5 -9 0 -5 -17 4 -13 7
--34 7 -46 0 -19 6 -23 31 -23 30 0 31 1 17 22 -8 13 -17 36 -20 51 l-5 28 28
--27 c16 -15 32 -24 36 -21 9 9 -47 68 -59 61 -14 -9 -9 2 13 27 16 18 19 31
-14 59 -4 19 -11 37 -16 38 -5 2 -9 13 -9 23 0 49 -35 74 -60 44z"/>
-				</g>
-			</svg>
-			Necromancer Builds
-		</td>
-		<td>Tier</td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	</thead>
-
-
-	<!--Necromancer-->
-	<tbody class="table-group-divider table-necro" id="tbodyNecromancer">
-	<tr>
-		<td>Poison Nova</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=99&difficulty=3&quests=1&strength=36&dexterity=0&vitality=0&energy=469&coupling=1&skills=000101011001011500001220010201200000002001000001000000010000010000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CGriffon%27s+Eye%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Necromancer%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Skullder%27s+Ire%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Trang-Oul%27s+Girth%2C3%2Cnone%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Death%27s+Web%2C3%2C%2B+Psn+Pierce%2C%2C%2C%2C%2C%2C&offhand=Trang-Oul%27s+Wing%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B3%25+Infectious+Large+Charm&charm=%2B1+Fungal+Grand+Charm+%2B+fhr">
-			<span class="badge rounded-pill text-bg-primary">Build Planner</span></a>
-		</td>
-
-
-	</tr>
-	<tr>
-		<td>Desecrate</td>
-		<td><span class="badge rounded-pill text-bg-danger">Bad</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Poison Strike</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=81&dexterity=53&vitality=226&energy=50&coupling=1&skills=000000010500100100000020012001200000000000000000000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Angelic+Mantle%2C1%2C%2B+Sockets+Chest%2C%2C%2C%2C%2C%2C&gloves=Sigon%27s+Gage%2C1%2Cnone&boots=Sigon%27s+Sabot%2C1%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Angelic+Wings%2C0%2Cnone%2C&ring1=Angelic+Halo%2C0%2Cnone&ring2=Angelic+Halo%2C0%2Cnone&weapon=The+Jade+Tan+Do%2C1%2C%2B+Sockets+Weapon%2C%2C%2C%2CShael+Rune%2CShael+Rune%2CShael+Rune&offhand=Rhyme+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Poison+Strike%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Starter Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=90&difficulty=3&quests=1&strength=83&dexterity=53&vitality=224&energy=100&coupling=1&skills=000000011500150701000020012001200000000000000000000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CRockstopper%2CRockfleece%2CPus+Spitter%2Cnone%2CLava+Gout%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Trang-Oul%27s+Guise%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Trang-Oul%27s+Scales%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Increased+Attack+Speed&boots=Silkweave%2C2%2C%2B+Life+per+kill&belt=Trang-Oul%27s+Girth%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Angelic+Wings%2C0%2C%2B+All+Skills%2C&ring1=Raven+Frost%2C0%2C%2B+Life+per+kill&ring2=Angelic+Halo%2C0%2C%2B+Life+per+kill&weapon=Blackbog%27s+Sharp%2C2%2C%2B+Sockets+Weapon%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CShael+Rune%2CScintillating+Jewel+of+Fervor&offhand=Trang-Oul%27s+Wing%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Vigor-mercenary%2C1%2C0&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm&charm=%2B1+Fungal+Grand+Charm">
-				<span class="badge rounded-pill text-bg-primary">Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=86&difficulty=3&quests=1&strength=20&dexterity=40&vitality=380&energy=0&coupling=1&skills=000000012000011300000020012001200000000000000000000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Prayer%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2Cnone%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CBloodfist%2CSandstorm+Trek%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29%2CRainbow+Facet+%28Poison%29&armor=Innocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Marrowwalk%2C3%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+All+Resistances%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Mana+per+kill&weapon=Plague+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Cinquedeas%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Martyrdom%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Cleansing-weapon%2C1%2C0&effect=Prayer-mercenary%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm+of+Vita">
-				<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Corpse Explosion</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=0&energy=0&coupling=1&skills=000101010001010500002001000020200000000020000000000000000000000000&mercenary=Ascendant+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Amplify+Damage%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Spirit+Forge%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Corpse+Explosion%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Corpse+Explosion%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Starter Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=102&dexterity=0&vitality=0&energy=378&coupling=1&skills=000101010101011501002001010120200000000020000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CMarrowwalk%2CNosferatu%27s+Coil&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Corpsemourn%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&gloves=Magefist%2C1%2C%2B+Mana+per+kill&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Max+Resist%2C&amulet=Venomous+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Life+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Mang+Song%27s+Lesson%2C3%2C%2B+Sockets+Weapon%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Inferno+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm">
-				<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=102&dexterity=0&vitality=0&energy=378&coupling=1&skills=000101010101011501002001010120200000000020000000000000000000000000&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CDream+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2COrmus%27+Robes%2CEschuta%27s+temper%2CDream+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CTrang-Oul%27s+Claws%2CMarrowwalk%2CArachnid+Mesh&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&armor=Ormus%27+Robes%2C3%2C%2B+Sockets+Chest%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Venomous+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Mana+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Death%27s+Web%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Darkforce+Spawn%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Shock-mercenary_helm%2C0%2C0&effect=Holy_Shock-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Inferno+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+fhr&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=%2B1+Fungal+Grand+Charm+%2B+life&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm&charm=Shimmering+Small+Charm">
-				<span class="badge rounded-pill text-bg-primary">Alt End-game Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Elemental Summoner (Mage Skeles + Ele Revives)</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=92&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=200101010120010101002000010100000000000001000001000000010001200010&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CImp+Shank%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Harlequin+Crest%2C3%2C%2B+Skill%2C%2CUm+Rune%2CUm+Rune&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Gravepalm%2C2%2C%2B+Faster+Cast+Rate&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+Faster+Cast+Rate%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Grim%27s+Burning+Dead%2C2%2C%2B+All+Skills%2C%2C%2CIst+Rune%2CIst+Rune%2CIst+Rune%2CScintillating+Jewel+of+Freedom&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=Amber+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Fire Golems</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000202000200120200000000000000000000001000001000000010000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CGore+Rider%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Golemlord%27s+Diadem+of+the+Magus%2C3%2C%2B+Skill%2C%2C%2C&armor=Trang-Oul%27s+Scales%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Golemlord%27s+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Golemlord%27s+Tomb+Wand+of+the+Archmage%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=Golemlord%27s+Minion+Skull+of+the+Archmage%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life">
-			<span class="badge rounded-pill text-bg-primary">Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Green Goblin (Demon Machine Merc + Skeletons)</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5"><span class="badge rounded-pill text-bg-secondary">Must gear swap pre-buff</span>
-			<span class="badge rounded-pill text-bg-secondary">Must have Innocence on Merc</span></td>
-	</tr>
-	<tr>
-		<td>Pure Revive (Eternity + Sacred Totem)</td>
-		<td><span class="badge rounded-pill text-bg-danger">Bad</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Dark Pact</td>
-		<td><span class="badge rounded-pill text-bg-info">Top</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=95&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000010100010101000000010100000000000020012001200000010016000020&mercenary=Barbarian+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Might%29%2CVeil+of+Steel%2CPurgatory%2Cnone%2Cnone%2CSteelrend%2CWar+Traveler%2CNosferatu%27s+Coil&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Accursed+Diadem%2C3%2C%2B+Skill%2C%2CLPK%2FMPK+req+FHR+Jewel%2CLPK%2FMPK+req+FHR+Jewel&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Mana+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Accursed+Amulet%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=Wisp+Projector%2C0%2C%2B+Mana+per+kill&weapon=Blackhand+Key%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2CLPK%2FMPK+Jewel%2CLPK%2FMPK+Jewel&offhand=Darkforce+Spawn%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Might-mercenary%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Hexing+Grand+Charm+%2B+fhr&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=Emerald+Small+Charm+of+Vita">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Teeth / Bonespear</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=269&energy=50&coupling=1&skills=000000010000010900000000202000002000200000000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-				<span class="badge rounded-pill text-bg-primary">Starter Build Planner</span></a>
-		</td>
-	</tr>
-	</tbody>
-
-	<thead id="theadPaladin">
-	<tr>
-		<td>
-			<svg xmlns="http://www.w3.org/2000/svg"
-			     width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000"
-			     preserveAspectRatio="xMidYMid meet">
-				<g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
-				   fill="#fff" stroke="none">
-					<path d="M217 314 c-4 -4 -7 -18 -7 -31 0 -18 -5 -23 -26 -23 -21 0 -24 -3
--15 -14 21 -25 -23 -97 -49 -81 -15 9 -12 -7 6 -33 14 -20 42 -33 30 -14 -8
-13 28 52 53 57 13 2 20 1 17 -3 -4 -4 -13 -7 -19 -7 -14 0 -29 -53 -23 -85 5
--30 0 -40 -34 -63 -24 -17 -22 -17 65 -17 51 0 84 4 77 9 -20 12 -9 96 20 157
-7 15 7 28 -1 43 -7 12 -9 26 -6 31 3 6 -5 10 -18 10 -22 0 -25 4 -23 33 1 25
--3 33 -19 35 -12 2 -24 0 -28 -4z m62 -91 c-6 -7 -15 -10 -20 -7 -5 3 -9 -1
--9 -9 0 -8 -9 -17 -21 -20 -14 -4 -23 1 -29 16 l-9 22 0 -22 c-1 -13 -5 -23
--11 -23 -5 0 -6 9 -1 21 5 15 18 23 41 26 18 2 35 5 37 6 2 2 10 4 18 4 11 0
-12 -4 4 -14z m-2 -50 c-4 -3 -2 -12 4 -20 9 -10 8 -17 -1 -28 -17 -21 -41 -19
--47 4 -3 13 -10 18 -21 14 -10 -4 -6 3 8 15 22 19 74 33 57 15z m-37 -134 c-8
--15 -8 -17 5 -13 8 4 15 1 15 -5 0 -14 -27 -14 -35 0 -4 6 -4 27 0 47 7 34 8
-35 16 14 6 -15 5 -31 -1 -43z"/>
-					<path d="M75 90 c-21 -22 -35 -43 -32 -47 4 -4 26 11 48 34 23 22 37 43 32 46
--5 4 -27 -12 -48 -33z"/>
-				</g>
-			</svg>
-			Paladin Builds
-		</td>
-		<td>Tier</td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	</thead>
-
-
-	<!--Paladin-->
-	<tbody class="table-group-divider table-light table-paladin" id="tbodyPaladin">
-	<tr>
-		<td>Holy Bolt / FOH</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=80&difficulty=3&quests=1&strength=40&dexterity=0&vitality=370&energy=0&coupling=1&skills=010001000000010003000000000000000000000000012000010001010120002020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CRockfleece%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CLaying+of+Hands%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Rose+Branded+Diadem%2C3%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=Lenymo%2C1%2Cnone%2C&amulet=Rose+Branded+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Neophyte+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Scepter%2C1%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Spirit+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Rondache%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0">
-			<span class="badge rounded-pill text-bg-primary">Starter Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=82&difficulty=3&quests=1&strength=66&dexterity=80&vitality=274&energy=0&coupling=1&skills=010001000000010001000000000000000000000001012001010101010120012020&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CVampire+Gaze%2CHeavenly+Garb%2CStormspire%2Cnone%2CLava+Gout%2CRite+of+Passage%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griswold%27s+Valor%2C3%2C%2B+Max+Lightning+Resist%2C%2C%2C&armor=Griswold%27s+Heart%2C3%2C%2B+Max+Cold+Resist%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2Cnone&boots=Waterwalk%2C3%2Cnone&belt=Verdungo%27s+Hearty+Cord%2C3%2Cnone%2C&amulet=Rose+Branded+Amulet%2C0%2Cnone%2C&ring1=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&ring2=Brilliant+Craft+Ring+%2B+FCR%2C0%2Cnone&weapon=Griswold%27s+Redemption%2C3%2Cnone%2C%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune&offhand=Griswold%27s+Honor%2C3%2C%2B+Max+Poison+Resist%2C%2C%2C%2CPerfect+Diamond%2CPerfect+Diamond%2CPerfect+Diamond&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Sanctuary-mercenary_armor%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=Annihilus&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Balance">
-				<span class="badge rounded-pill text-bg-primary">Mid-Game Build Planner</span></a>
-			<a target="_blank"
-			   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=66&dexterity=0&vitality=439&energy=0&coupling=1&skills=010602040006010001000000000000000000000001012001010101010120012020&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CCrown+of+Ages%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CAzurewrath%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2CVenom+Grip%2CTancred%27s+Hobnails%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griswold%27s+Valor%2C3%2C%2B+Skill%2C%2C%2C&armor=Griswold%27s+Heart%2C3%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+FBR&boots=Waterwalk%2C3%2C%2B+Max+Poison+Resist&belt=Arachnid+Mesh%2C3%2C%2B+PDR%2C&amulet=Rose+Branded+Amulet%2C0%2C%2B+All+Skills%2C&ring1=Wisp+Projector%2C0%2C%2B+Damage+Reduction&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Damage+Reduction&weapon=Griswold%27s+Redemption%2C3%2C%2B+All+Skills%2C%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune%2CTir+Rune&offhand=Griswold%27s+Honor%2C3%2C%2B+All+Skills%2C%2C%2C%2CUm+Rune%2CUm+Rune%2CUm+Rune&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Sanctuary-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=%2B1+Lion+Branded+Grand+Charm+%2B+fhr&charm=%2B3%25+Scintillating+Large+Charm+of+Balance&charm=%2B3%25+Scintillating+Large+Charm+of+Vita&charm=Annihilus+%2B2&charm=%2B3%25+Scintillating+Large+Charm+of+Balance">
-				<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Hammerdin</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=010001000000200000000100002020000000000001010101010120000000200100&mercenary=Iron+Wolf+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Static+Field%29%2CGriffon%27s+Eye%2CDark+Abyss%2CDoom+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2CExile+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2COccultist%2CImp+Shank%2CSiggard%27s+Staunch&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=2%2F20+Circlet+Paladin%2C3%2C%2B+Skill%2C%2C%2C&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Occultist%2C3%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Paladin%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Akarat%27s+Devotion%2C3%2C%2B+Faster+Cast+Rate%2C%2C%2C%2C%2C%2C&offhand=Herald+of+Zakarum%2C1%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Freeze-mercenary_weapon%2C1%2C0&effect=Defiance-mercenary_offhand%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm&charm=%2B3%25+Scintillating+Large+Charm">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Vengeance 2H Zenith</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120010000032001002001010001012000000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Griswold%27s+Heart%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Zenith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Colossus+Sword%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Salvation-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Vengeance 1H</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000000000000000000120010000032001002001010001012000000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Griswold%27s+Heart%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Dracul%27s+Grasp%2C3%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+All+Skills%2C&ring1=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&ring2=The+Stone+of+Jordan%2C0%2C%2B+Life+per+kill&weapon=Lightsabre%2C3%2C%2B+Sockets+Weapon%2C%2C%2C%2C%2C%2C&offhand=Dragonscale%2C3%2C%2B+Sockets+Off-hand%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Resist_Lightning-weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Captain%27s+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm&charm=%2B1+Lion+Branded+Grand+Charm">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a></td>
-	</tr>
-	<tr>
-		<td>Ele - Sacrifice (Native Ele Aura)</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Ele - Charge (Native Ele Aura)</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Holy Shock - Multishot (Native Ele Aura)</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Auradin - Charge (HOJ + 2x Dragon)</td>
-		<td><span class="badge rounded-pill text-bg-primary">Good</span></td>
-
-
-		<td colspan="5"><a target="_blank"
-		                   href="https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=paladin&level=99&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=002000000000000000200101012000010001002001010001010100000000200000&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone%2Cnone&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Kira%27s+Guardian%2C2%2C%2B+Sockets+Helm%2C%2C%2CRainbow+Facet+%28Fire%29&armor=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+Increased+Attack+Speed&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=The+Rising+Sun%2C0%2C%2B+2+All+Skills%2C&ring1=Raven+Frost%2C0%2C%2B+Life+per+kill&ring2=Wisp+Projector%2C0%2C%2B+Life+per+kill&weapon=Hand+of+Justice+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Phase+Blade%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Dragon+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Vortex+Shield%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Holy_Fire-armor%2C0%2C0&effect=Holy_Fire-weapon%2C0%2C0&effect=Holy_Fire-combined%2C1%2C0&effect=Holy_Fire-offhand%2C0%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm&charm=%2B3%25+Inferno+Large+Charm">
-			<span class="badge rounded-pill text-bg-primary">End-game Build Planner</span></a>
-		</td>
-	</tr>
-	<tr>
-		<td>Physical Zeal</td>
-		<td><span class="badge rounded-pill text-bg-danger">Bad</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	<tr>
-		<td>Physical Sacrifice</td>
-		<td><span class="badge rounded-pill text-bg-warning">Mid</span></td>
-
-
-		<td colspan="5"><span class="badge rounded-pill text-bg-secondary">Requires Leech-able Mobs</span></td>
-	</tr>
-	<tr>
-		<td>Physical Charge (2-H)</td>
-		<td><span class="badge rounded-pill text-bg-success">Decent</span></td>
-
-
-		<td colspan="5">-</td>
-	</tr>
-	</tbody>
-
+<table class="table table-striped table-dark" id="mainTable">
 </table>
 
 <script crossorigin="anonymous"
@@ -2077,141 +716,480 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
         integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y"
         src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js">-
 </script>
+<script src="solo-data.js"></script>
 <script>
-	const checkboxStarter = document.getElementById('checkboxStarter');
-	  const contentStarter = document.getElementById('tbodyStarter');
-	  const headerStarter = document.getElementById('theadStarter');
 
-	  checkboxStarter.addEventListener('change', function() {
-		  if (this.checked) {
-			  contentStarter.style.display = ''; // Show the element
-			  headerStarter.style.display = ''; // Show the element
-		  } else {
-			  contentStarter.style.display = 'none';  // Hide the element
-			  headerStarter.style.display = 'none';  // Hide the element
-		  }
-	  });
-</script>
-<script>
-	const checkboxSorceress = document.getElementById('checkboxSorceress');
-	  const contentSorceress = document.getElementById('tbodySorceress');
-	  const headerSorceress = document.getElementById('theadSorceress');
+const classSvgs = {
+  'Starter': `<svg xmlns="http://www.w3.org/2000/svg" width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000" preserveAspectRatio="xMidYMid meet"> <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"> <path d="M6 303 c4 -10 7 -36 6 -58 -2 -33 3 -44 27 -65 21 -17 36 -46 50 -93 12 -38 18 -73 15 -78 -3 -5 33 -9 83 -9 55 0 83 4 74 9 -11 7 -12 25 -7 82 11 112 10 126 -10 156 -10 15 -18 34 -19 42 0 8 -7 18 -17 24 -20 13 -48 -6 -48 -35 0 -25 -23 -68 -48 -91 -19 -18 -21 -17 -47 9 -20 20 -25 33 -20 51 3 16 0 34 -10 49 -18 28 -41 33 -29 7z m28 -65 c-5 -31 -3 -38 9 -38 9 0 21 -10 27 -22 9 -20 9 -21 -2 -7 -7 8 -21 18 -32 22 -15 6 -17 14 -13 44 4 20 2 45 -4 57 -10 20 -10 20 5 2 11 -14 14 -31 10 -58z m186 51 c0 -13 -14 -11 -28 3 -7 7 -12 8 -12 4 0 -10 40 -46 51 -46 6 0 29 -54 29 -70 0 -4 -9 -17 -20 -30 -22 -26 -25 -22 -9 12 7 16 7 31 0 48 -9 20 -11 21 -10 5 3 -43 0 -48 -16 -35 -20 16 -19 29 3 53 9 11 12 18 7 15 -22 -13 -44 20 -37 54 3 9 42 -3 42 -13z m-38 -60 c-27 -10 -28 -20 -3 -38 11 -8 17 -20 14 -28 -3 -7 0 -13 6 -13 6 0 11 -9 11 -20 0 -11 5 -20 10 -20 6 0 10 -15 10 -33 0 -31 -2 -33 -36 -35 l-35 -3 7 61 c4 40 2 70 -6 90 -11 27 -11 32 6 45 10 7 23 11 28 7 5 -3 0 -9 -12 -13z m-32 -89 c-7 -17 -10 -48 -7 -70 7 -51 -8 -52 -19 -3 -12 56 -12 73 -3 67 5 -3 9 1 9 8 0 16 21 40 28 33 3 -2 -1 -18 -8 -35z"/> </g> </svg>`,
+  'Sorceress': `<svg xmlns="http://www.w3.org/2000/svg" width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000" preserveAspectRatio="xMidYMid meet"> <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"> <path d="M156 296 c-9 -14 -27 -28 -41 -32 -14 -3 -25 -9 -25 -14 0 -13 37 -40 45 -33 4 5 5 0 2 -10 -4 -12 -3 -16 4 -11 7 4 9 -3 7 -17 -2 -15 2 -23 10 -21 6 1 11 -1 11 -5 -3 -21 3 -21 27 -1 l25 23 -21 17 c-11 9 -28 14 -35 11 -22 -8 -18 7 7 34 12 13 16 23 10 23 -14 0 -16 36 -2 45 6 4 7 -1 4 -12 -5 -16 -3 -15 11 2 15 19 16 19 10 -15 -3 -19 -10 -36 -15 -38 -6 -2 1 -18 15 -36 14 -18 22 -36 18 -39 -3 -4 -1 -7 6 -7 21 0 23 27 4 91 -22 74 -48 89 -77 45z"/> <path d="M5 290 c-3 -6 23 -38 59 -71 55 -52 64 -65 61 -90 -4 -35 -14 -51 -26 -44 -5 3 -6 -1 -3 -10 6 -15 -29 -57 -58 -68 -7 -3 12 -6 42 -6 35 0 50 2 41 8 -11 7 -7 18 20 56 32 44 34 46 40 23 11 -39 10 -76 -3 -82 -7 -2 17 -4 54 -4 74 1 77 8 24 57 -17 16 -24 31 -21 42 4 10 1 27 -5 39 l-11 20 -21 -20 -22 -20 -23 21 c-12 12 -20 25 -18 29 4 7 -108 130 -119 130 -2 0 -8 -5 -11 -10z m158 -166 c8 -9 -15 -44 -30 -44 -19 0 -3 30 16 31 12 0 12 2 -4 9 -15 6 -16 9 -4 9 9 1 18 -2 22 -5z m57 -19 c-5 -6 -8 -14 -5 -17 3 -2 -2 -5 -10 -5 -8 0 -12 4 -9 8 2 4 0 10 -6 14 -17 10 -2 24 20 18 15 -4 18 -9 10 -18z m25 -64 c25 -27 26 -30 7 -28 -11 0 -18 5 -15 10 3 4 -3 7 -13 5 -13 -2 -20 4 -22 20 -5 30 9 28 43 -7z"/> </g> </svg>`,
+  'Druid': `<svg xmlns="http://www.w3.org/2000/svg" width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000" preserveAspectRatio="xMidYMid meet"> <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"> <path d="M204 302 c-12 -9 -36 -25 -53 -34 -17 -9 -31 -23 -31 -29 0 -7 3 -9 7 -6 3 4 12 -1 20 -11 12 -15 12 -15 7 0 -6 18 22 38 53 38 14 0 12 -3 -7 -13 -14 -7 -26 -22 -28 -33 -2 -12 -16 -34 -32 -49 -30 -29 -55 -28 -85 1 -9 9 -15 11 -15 4 0 -6 -3 -9 -8 -6 -4 2 -13 -7 -19 -21 -11 -23 -10 -25 8 -20 17 5 18 3 7 -11 -11 -14 -10 -15 6 -9 24 9 36 -7 36 -50 0 -20 -7 -36 -17 -42 -14 -8 -10 -10 23 -11 38 0 41 2 37 24 -3 13 0 27 6 31 17 10 43 -16 38 -37 -4 -15 1 -18 34 -18 l39 0 1 43 c1 23 4 53 8 67 6 23 8 23 14 6 4 -11 4 -22 -1 -25 -5 -3 -9 -25 -9 -48 0 -42 0 -43 34 -43 31 0 33 1 19 16 -16 15 -21 45 -17 91 1 13 -3 31 -8 41 -6 11 -6 24 -1 32 7 11 11 8 19 -12 6 -15 8 -36 6 -48 -3 -14 0 -20 8 -17 7 2 12 26 12 62 1 53 -1 60 -26 74 -20 11 -26 22 -25 45 1 37 -27 46 -60 18z m50 -23 c-2 -17 -7 -36 -11 -42 -4 -7 -8 -18 -9 -25 -4 -25 -14 -26 -14 -1 0 14 5 30 12 37 9 9 9 12 0 12 -7 0 -12 11 -12 25 0 18 5 25 19 25 15 0 18 -6 15 -31z m35 -48 c8 -5 15 -22 17 -38 2 -27 2 -27 -8 -5 -11 22 -38 31 -38 12 0 -5 -5 -10 -12 -10 -9 0 -9 3 -1 11 6 6 9 18 6 25 -6 16 15 18 36 5z m-102 -75 c-2 -51 -3 -53 -24 -43 -13 6 -23 14 -23 19 0 5 4 7 9 4 11 -7 24 21 29 62 1 6 4 12 6 12 2 0 4 -24 3 -54z m71 -8 c7 -7 12 -19 12 -27 -1 -13 -2 -13 -11 2 -15 25 -27 21 -34 -13 -9 -39 -21 -38 -29 2 -4 21 -2 34 6 40 19 11 42 10 56 -4z m-156 -21 c7 -8 18 -12 24 -10 7 2 25 -8 40 -23 16 -14 22 -22 13 -16 -8 6 -27 9 -42 7 -19 -4 -29 0 -37 15 -6 11 -15 18 -19 16 -4 -3 -8 1 -8 9 0 19 11 19 29 2z"/> </g> </svg>`,
+  'Assassin': `<svg xmlns="http://www.w3.org/2000/svg" width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000" preserveAspectRatio="xMidYMid meet"> <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"> <path d="M174 306 c-4 -9 -4 -25 -1 -36 3 -14 -1 -20 -17 -22 -11 -2 -21 -10 -22 -18 -2 -32 -5 -38 -34 -75 -30 -37 -34 -63 -11 -58 6 2 11 -3 12 -10 0 -6 11 12 24 41 13 29 21 60 18 70 -4 11 2 8 17 -8 12 -14 27 -24 32 -22 5 1 7 -2 3 -8 -5 -8 -11 -8 -20 0 -9 8 -17 0 -32 -35 -11 -25 -19 -59 -18 -75 1 -16 -2 -27 -6 -25 -4 3 -20 -2 -35 -10 -28 -15 -28 -15 36 -15 41 0 60 4 51 9 -17 11 -7 73 14 95 8 8 15 22 15 30 0 9 5 16 10 16 13 0 13 -27 -1 -36 -6 -4 -8 -20 -4 -40 3 -19 1 -43 -5 -54 -10 -19 -8 -20 37 -19 26 1 40 3 31 6 -11 3 -20 18 -23 41 -16 104 -17 99 12 120 23 16 25 22 15 35 -7 8 -11 21 -10 28 2 7 -6 15 -17 18 -14 4 -20 15 -20 36 0 24 -5 31 -23 33 -13 2 -25 -3 -28 -12z m33 -18 c4 -7 6 -21 5 -30 -2 -13 3 -18 19 -18 18 0 19 -2 9 -15 -11 -14 -15 -14 -30 2 -10 10 -16 20 -14 22 2 2 -1 10 -7 18 -9 10 -8 13 2 13 11 0 11 2 -1 10 -9 6 -10 10 -3 10 6 0 15 -6 20 -12z m-18 -57 c10 -7 11 -13 2 -27 -8 -15 -11 -16 -12 -4 -1 8 -1 18 0 22 0 4 -5 5 -13 2 -8 -3 -17 -1 -21 5 -8 13 24 14 44 2z m81 -42 c0 -5 -11 -8 -24 -7 -20 2 -22 5 -13 20 8 12 15 14 24 6 7 -6 13 -14 13 -19z"/> </g> </svg>`,
+  'Barbarian': `<svg xmlns="http://www.w3.org/2000/svg" width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000" preserveAspectRatio="xMidYMid meet"> <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"> <path d="M132 308 c-7 -7 -12 -22 -12 -34 0 -17 -5 -20 -23 -17 -25 5 -45 -12 -52 -43 -2 -11 -9 -34 -14 -53 -12 -39 -8 -49 23 -61 30 -11 27 -41 -9 -74 l-28 -26 63 0 63 0 -6 39 c-6 45 7 76 18 42 3 -12 4 -35 0 -51 l-7 -30 54 1 c29 0 47 3 40 6 -9 3 -7 12 8 30 21 27 27 59 10 48 -6 -4 -19 -1 -28 6 -15 12 -14 11 1 -7 17 -20 17 -23 2 -38 -23 -22 -23 -21 -21 24 1 22 -1 40 -6 40 -4 0 -8 14 -8 31 0 26 3 29 14 20 8 -7 12 -21 9 -31 -7 -25 21 -37 43 -19 8 7 13 21 11 31 -3 10 -2 16 3 13 10 -6 45 33 37 42 -4 3 -16 -2 -27 -12 -19 -17 -20 -17 -28 6 -5 13 -7 29 -5 36 6 16 -33 36 -57 28 -10 -3 -22 0 -26 6 -4 8 -3 9 4 5 8 -5 12 1 12 16 0 17 3 19 9 9 5 -8 16 -11 27 -7 16 6 16 7 -2 21 -23 18 -76 19 -92 3z m43 -8 c4 -6 1 -17 -5 -25 -10 -12 -10 -18 -1 -29 10 -12 8 -17 -11 -28 -13 -7 -33 -13 -45 -15 -21 -2 -21 -1 -5 18 17 19 38 27 27 9 -3 -6 1 -7 9 -4 14 5 13 9 -1 30 -14 22 -14 24 3 25 11 0 14 3 7 6 -7 2 -13 9 -13 14 0 12 27 11 35 -1z m-78 -65 c0 -14 -26 -30 -35 -21 -2 3 -2 12 1 21 8 19 34 20 34 0z m118 -2 c-19 -15 -19 -15 10 -9 22 5 26 4 15 -4 -18 -12 -60 -13 -60 -2 0 13 23 32 40 32 12 -1 11 -4 -5 -17z m34 -46 c-1 -7 1 -20 6 -30 9 -21 -8 -46 -19 -28 -4 6 -2 11 4 11 6 0 -1 11 -16 25 -21 19 -30 22 -40 14 -8 -6 -21 -9 -29 -5 -9 3 -15 0 -15 -9 0 -8 -7 -15 -15 -15 -8 0 -15 7 -15 16 0 14 -3 14 -16 4 -12 -11 -18 -10 -32 5 -9 10 -12 15 -5 11 6 -3 14 0 16 6 4 9 8 9 14 3 13 -16 28 -16 90 -1 60 14 75 12 72 -7z m-79 -31 c0 -8 -68 -46 -81 -45 -11 0 -11 2 -1 6 9 3 10 9 3 17 -8 10 -4 11 18 8 16 -2 32 1 35 7 7 11 26 16 26 7z m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0 -16 0 -29 27 -20 41 11 18 37 10 31 -11z m-74 -67 c10 -10 -13 -33 -34 -33 -10 0 -20 4 -23 9 -4 5 5 8 19 6 14 -1 28 2 32 8 3 6 1 7 -5 3 -6 -3 -13 -2 -17 4 -7 11 18 14 28 3z"/> <path d="M24 211 c4 -6 1 -14 -7 -16 -7 -3 -13 -15 -12 -25 2 -33 10 -31 21 6 8 23 8 37 1 41 -6 3 -7 1 -3 -6z"/> </g> </svg>`,
+  'Amazon': `<svg xmlns="http://www.w3.org/2000/svg" width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000" preserveAspectRatio="xMidYMid meet"> <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"> <path d="M213 305 c-3 -9 -3 -24 0 -35 3 -11 0 -20 -5 -20 -6 0 -25 -16 -42 -36 l-31 -36 -42 46 c-23 25 -39 46 -35 46 4 1 -6 8 -21 16 -36 20 -43 13 -23 -23 8 -15 15 -24 16 -20 0 15 158 -148 165 -171 3 -12 11 -19 17 -16 7 4 8 2 4 -5 -4 -6 -12 -8 -18 -5 -6 4 -8 -1 -3 -15 4 -13 2 -21 -5 -21 -6 0 -8 5 -5 10 8 12 -8 13 -21 1 -5 -5 -18 -11 -29 -14 -11 -3 12 -5 50 -6 39 0 65 3 58 7 -7 4 -10 27 -8 57 1 28 3 61 4 74 1 30 18 17 24 -19 3 -14 8 -38 11 -55 6 -27 5 -27 -4 -7 -5 13 -15 20 -20 17 -8 -5 -7 -12 2 -22 7 -9 12 -18 11 -20 -2 -1 -3 -10 -3 -18 0 -10 10 -15 31 -15 31 0 31 0 15 25 -9 13 -18 37 -20 52 -2 16 -8 41 -15 56 -14 35 -14 60 -1 52 12 -8 13 5 1 24 -8 12 -12 12 -25 2 -12 -11 -16 -11 -16 -1 0 10 -3 10 -15 0 -10 -9 -15 -9 -15 -1 0 11 13 15 38 12 6 -1 12 3 12 9 0 5 -5 10 -11 10 -5 0 -8 4 -4 9 3 5 1 12 -5 16 -16 10 -11 23 8 20 9 -1 16 -9 14 -19 -2 -9 7 -26 18 -38 14 -15 19 -31 15 -45 -3 -12 -1 -25 5 -28 5 -3 10 -12 10 -18 0 -7 -4 -6 -11 3 -9 12 -10 12 -7 1 8 -29 28 -23 28 7 0 37 -26 102 -41 102 -7 0 -8 7 -4 18 4 9 8 23 8 30 0 15 12 5 12 -10 0 -6 6 -13 13 -16 10 -3 10 2 1 21 -8 18 -19 24 -45 25 -23 1 -37 -4 -41 -13z m-14 -127 c0 -7 -4 -21 -8 -31 -6 -17 -8 -17 -20 -3 -11 13 -11 19 -1 31 15 18 30 20 29 3z"/> </g> </svg>`,
+  'Necromancer': `<svg xmlns="http://www.w3.org/2000/svg" width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000" preserveAspectRatio="xMidYMid meet"> <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"> <path d="M25 295 c-24 -23 -36 -73 -15 -60 5 3 7 0 4 -8 -3 -8 1 -19 9 -25 12 -10 13 -8 10 12 -7 34 14 68 37 61 23 -7 36 11 20 30 -18 21 -37 18 -65 -10z"/> <path d="M200 305 c-7 -8 -10 -24 -7 -35 3 -12 0 -20 -7 -20 -7 0 -17 -5 -24 -12 -9 -9 -8 -16 5 -32 10 -12 11 -15 3 -9 -9 9 -17 9 -26 2 -13 -11 -14 6 -2 27 4 6 -3 21 -16 33 -15 15 -26 19 -31 12 -6 -10 0 -15 17 -12 4 0 5 -6 2 -14 -4 -8 -3 -26 0 -39 5 -19 12 -24 34 -23 20 2 26 -2 22 -13 -4 -14 -3 -73 3 -114 1 -12 -10 -25 -33 -37 l-35 -19 55 0 55 0 -2 53 c-2 75 -2 77 -12 77 -4 0 -6 -12 -3 -26 3 -17 1 -25 -5 -21 -16 10 -22 66 -7 60 9 -3 12 2 9 16 -3 15 0 19 8 14 9 -5 9 -3 0 8 -17 20 -16 27 1 54 10 15 12 26 6 30 -15 10 -12 35 6 42 9 3 20 0 24 -8 13 -20 0 -32 -17 -17 -15 12 -15 11 -3 -9 11 -16 11 -27 3 -45 -7 -16 -8 -30 -1 -41 6 -11 5 -17 -2 -17 -6 0 -8 -4 -5 -10 10 -17 21 -11 34 16 10 22 9 28 -5 39 -14 10 -15 13 -3 20 8 5 11 5 7 0 -5 -5 1 -14 12 -22 11 -8 20 -22 20 -31 0 -15 -2 -15 -10 -2 -8 13 -10 13 -10 -2 0 -9 -9 -23 -19 -30 -14 -10 -17 -18 -10 -28 13 -21 11 -43 -3 -34 -8 5 -9 0 -5 -17 4 -13 7 -34 7 -46 0 -19 6 -23 31 -23 30 0 31 1 17 22 -8 13 -17 36 -20 51 l-5 28 28 -27 c16 -15 32 -24 36 -21 9 9 -47 68 -59 61 -14 -9 -9 2 13 27 16 18 19 31 14 59 -4 19 -11 37 -16 38 -5 2 -9 13 -9 23 0 49 -35 74 -60 44z"/> </g> </svg>`,
+  'Paladin': `<svg xmlns="http://www.w3.org/2000/svg" width="25.000000pt" height="25.000000pt" viewBox="0 0 32.000000 32.000000" preserveAspectRatio="xMidYMid meet"> <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"> <path d="M217 314 c-4 -4 -7 -18 -7 -31 0 -18 -5 -23 -26 -23 -21 0 -24 -3 -15 -14 21 -25 -23 -97 -49 -81 -15 9 -12 -7 6 -33 14 -20 42 -33 30 -14 -8 13 28 52 53 57 13 2 20 1 17 -3 -4 -4 -13 -7 -19 -7 -14 0 -29 -53 -23 -85 5 -30 0 -40 -34 -63 -24 -17 -22 -17 65 -17 51 0 84 4 77 9 -20 12 -9 96 20 157 7 15 7 28 -1 43 -7 12 -9 26 -6 31 3 6 -5 10 -18 10 -22 0 -25 4 -23 33 1 25 -3 33 -19 35 -12 2 -24 0 -28 -4z m62 -91 c-6 -7 -15 -10 -20 -7 -5 3 -9 -1 -9 -9 0 -8 -9 -17 -21 -20 -14 -4 -23 1 -29 16 l-9 22 0 -22 c-1 -13 -5 -23 -11 -23 -5 0 -6 9 -1 21 5 15 18 23 41 26 18 2 35 5 37 6 2 2 10 4 18 4 11 0 12 -4 4 -14z m-2 -50 c-4 -3 -2 -12 4 -20 9 -10 8 -17 -1 -28 -17 -21 -41 -19 -47 4 -3 13 -10 18 -21 14 -10 -4 -6 3 8 15 22 19 74 33 57 15z m-37 -134 c-8 -15 -8 -17 5 -13 8 4 15 1 15 -5 0 -14 -27 -14 -35 0 -4 6 -4 27 0 47 7 34 8 35 16 14 6 -15 5 -31 -1 -43z"/> <path d="M75 90 c-21 -22 -35 -43 -32 -47 4 -4 26 11 48 34 23 22 37 43 32 46 -5 4 -27 -12 -48 -33z"/> </g> </svg>`
+};
 
-	  checkboxSorceress.addEventListener('change', function() {
-		  if (this.checked) {
-			  contentSorceress.style.display = ''; // Show the element
-			  headerSorceress.style.display = ''; // Show the element
-		  } else {
-			  contentSorceress.style.display = 'none';  // Hide the element
-			  headerSorceress.style.display = 'none';  // Hide the element
-		  }
-	  });
-</script>
-<script>
-	const checkboxDruid = document.getElementById('checkboxDruid');
-	  const contentDruid = document.getElementById('tbodyDruid');
-	  const headerDruid = document.getElementById('theadDruid');
+const classTableStyles = {
+  'Sorceress': 'table-sorc',
+  'Druid': 'table-druid',
+  'Assassin': 'table-assassin',
+  'Barbarian': 'table-barbarian',
+  'Amazon': 'table-amazon',
+  'Necromancer': 'table-necro',
+  'Paladin': 'table-paladin'
+};
 
-	  checkboxDruid.addEventListener('change', function() {
-		  if (this.checked) {
-			  contentDruid.style.display = ''; // Show the element
-			  headerDruid.style.display = ''; // Show the element
-		  } else {
-			  contentDruid.style.display = 'none';  // Hide the element
-			  headerDruid.style.display = 'none';  // Hide the element
-		  }
-	  });
-</script>
-<script>
-	const checkboxAssassin = document.getElementById('checkboxAssassin');
-	  const contentAssassin = document.getElementById('tbodyAssassin');
-	  const headerAssassin = document.getElementById('theadAssassin');
+const tierStyles = {
+  'Top': 'text-bg-info',
+  'Good': 'text-bg-primary',
+  'Decent': 'text-bg-success',
+  'Mid': 'text-bg-warning',
+  'Bad': 'text-bg-danger',
+  'Travincal': 'text-bg-secondary'
+};
 
-	  checkboxAssassin.addEventListener('change', function() {
-		  if (this.checked) {
-			  contentAssassin.style.display = ''; // Show the element
-			  headerAssassin.style.display = ''; // Show the element
-		  } else {
-			  contentAssassin.style.display = 'none';  // Hide the element
-			  headerAssassin.style.display = 'none';  // Hide the element
-		  }
-	  });
-</script>
-<script>
-	const checkboxBarbarian = document.getElementById('checkboxBarbarian');
-	  const contentBarbarian = document.getElementById('tbodyBarbarian');
-	  const headerBarbarian = document.getElementById('theadBarbarian');
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
 
-	  checkboxBarbarian.addEventListener('change', function() {
-		  if (this.checked) {
-			  contentBarbarian.style.display = ''; // Show the element
-			  headerBarbarian.style.display = ''; // Show the element
-		  } else {
-			  contentBarbarian.style.display = 'none';  // Hide the element
-			  headerBarbarian.style.display = 'none';  // Hide the element
-		  }
-	  });
-</script>
-<script>
-	const checkboxAmazon = document.getElementById('checkboxAmazon');
-	  const contentAmazon = document.getElementById('tbodyAmazon');
-	  const headerAmazon = document.getElementById('theadAmazon');
+function renderStarterRow(build) {
+  const tableClass = classTableStyles[build.className] || '';
+  const tr = document.createElement('tr');
+  tr.className = tableClass;
 
-	  checkboxAmazon.addEventListener('change', function() {
-		  if (this.checked) {
-			  contentAmazon.style.display = ''; // Show the element
-			  headerAmazon.style.display = ''; // Show the element
-		  } else {
-			  contentAmazon.style.display = 'none';  // Hide the element
-			  headerAmazon.style.display = 'none';  // Hide the element
-		  }
-	  });
-</script>
-<script>
-	const checkboxNecromancer = document.getElementById('checkboxNecromancer');
-	  const contentNecromancer = document.getElementById('tbodyNecromancer');
-	  const headerNecromancer = document.getElementById('theadNecromancer');
+  const tdName = document.createElement('td');
+  if (build.plannerUrl) {
+    tdName.innerHTML = '<span class="badge text-bg-secondary">' + escapeHtml(build.className) + '</span> ' + escapeHtml(build.buildName);
+  } else {
+    tdName.textContent = build.buildName;
+  }
+  tr.appendChild(tdName);
 
-	  checkboxNecromancer.addEventListener('change', function() {
-		  if (this.checked) {
-			  contentNecromancer.style.display = ''; // Show the element
-			  headerNecromancer.style.display = ''; // Show the element
-		  } else {
-			  contentNecromancer.style.display = 'none';  // Hide the element
-			  headerNecromancer.style.display = 'none';  // Hide the element
-		  }
-	  });
-</script>
-<script>
-	const checkboxPaladin = document.getElementById('checkboxPaladin');
-	  const contentPaladin = document.getElementById('tbodyPaladin');
-	  const headerPaladin = document.getElementById('theadPaladin');
+  const tdPlanner = document.createElement('td');
+  if (build.plannerUrl) {
+    const a = document.createElement('a');
+    a.target = '_blank';
+    a.href = build.plannerUrl;
+    a.innerHTML = '<span class="badge rounded-pill text-bg-primary">' + escapeHtml(build.plannerLabel) + '</span>';
+    tdPlanner.appendChild(a);
+  } else {
+    tdPlanner.innerHTML = '<span class="badge text-bg-secondary">' + escapeHtml(build.className) + '</span>';
+  }
+  tr.appendChild(tdPlanner);
 
-	  checkboxPaladin.addEventListener('change', function() {
-		  if (this.checked) {
-			  contentPaladin.style.display = ''; // Show the element
-			  headerPaladin.style.display = ''; // Show the element
-		  } else {
-			  contentPaladin.style.display = 'none';  // Hide the element
-			  headerPaladin.style.display = 'none';  // Hide the element
-		  }
-	  });
-</script>
-<script>
-	const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
-</script>
-<script>
-	const allClassCheckboxes = ['checkboxStarter','checkboxSorceress','checkboxDruid','checkboxAssassin','checkboxBarbarian','checkboxAmazon','checkboxNecromancer','checkboxPaladin'];
-	function toggleAll(newState) {
-		allClassCheckboxes.forEach(id => {
-			const cb = document.getElementById(id);
-			if (cb.checked !== newState) {
-				cb.checked = newState;
-				cb.dispatchEvent(new Event('change'));
-			}
-		});
-	}
+  const tdTags = document.createElement('td');
+  tdTags.colSpan = 5;
+  let tagsHtml = '';
+  build.tags.forEach(function(tag) {
+    const pill = tag.pill ? 'rounded-pill ' : '';
+    tagsHtml += '<span class="badge ' + pill + 'text-bg-' + tag.style + '">' + escapeHtml(tag.text) + '</span>\n';
+  });
+  tdTags.innerHTML = tagsHtml;
+  tr.appendChild(tdTags);
+
+  return tr;
+}
+
+function renderClassBuildRow(build) {
+  const tr = document.createElement('tr');
+
+  const tdName = document.createElement('td');
+  tdName.textContent = build.buildName;
+  tr.appendChild(tdName);
+
+  const tdTier = document.createElement('td');
+  const tierStyle = tierStyles[build.tier] || 'text-bg-secondary';
+  tdTier.innerHTML = '<span class="badge rounded-pill ' + tierStyle + '">' + escapeHtml(build.tier) + '</span>';
+  tr.appendChild(tdTier);
+
+  const tdLinks = document.createElement('td');
+  tdLinks.className = 'align-middle';
+  tdLinks.colSpan = 5;
+
+  if (build.links.length === 0 && build.notes.length === 0) {
+    tdLinks.textContent = '-';
+  } else {
+    let linksHtml = '';
+    build.links.forEach(function(link) {
+      if (link.type === 'planner') {
+        linksHtml += '<a target="_blank" href="' + link.url + '"><span class="badge rounded-pill text-bg-primary">' + escapeHtml(link.label) + '</span></a>\n';
+      } else if (link.type === 'guide') {
+        linksHtml += '<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2" href="' + link.url + '" rel="noreferrer" target="_blank">' + escapeHtml(link.label) + '</a>\n';
+      } else if (link.type === 'video') {
+        linksHtml += '<span style="text-decoration:underline;text-decoration-skip-ink:none;-webkit-text-decoration-skip:none;color:#ff6d01;"><a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2" href="' + link.url + '" rel="noreferrer" target="_blank">' + escapeHtml(link.label) + '</a></span>\n';
+      }
+    });
+    build.notes.forEach(function(note) {
+      linksHtml += '<span class="badge rounded-pill text-bg-secondary">' + escapeHtml(note) + '</span>\n';
+    });
+    tdLinks.innerHTML = linksHtml;
+  }
+  tr.appendChild(tdLinks);
+
+  return tr;
+}
+
+function renderClassThead(className) {
+  const thead = document.createElement('thead');
+  thead.id = 'thead' + className;
+  const tr = document.createElement('tr');
+
+  const tdName = document.createElement('td');
+  if (className === 'Starter') {
+    tdName.colSpan = 1;
+  }
+  tdName.innerHTML = classSvgs[className] + '\n' + (className === 'Starter' ? 'Advised Starter Builds' : escapeHtml(className) + ' Builds');
+  tr.appendChild(tdName);
+
+  if (className === 'Starter') {
+    const tdNote = document.createElement('td');
+    tdNote.colSpan = 6;
+    tdNote.innerHTML = '<span class="badge text-bg-secondary">These planners are for when you finish Hell to farm your next gear step, scroll down for complete planners.</span>';
+    tr.appendChild(tdNote);
+  } else {
+    const tdTier = document.createElement('td');
+    tdTier.textContent = 'Tier';
+    tr.appendChild(tdTier);
+
+    const tdDash = document.createElement('td');
+    tdDash.colSpan = 5;
+    tdDash.textContent = '-';
+    tr.appendChild(tdDash);
+  }
+
+  thead.appendChild(tr);
+  return thead;
+}
+
+function loadData() {
+  // Try fetch first (works on http), fall back to script tag (works on file://)
+  if (window.soloData) {
+    return Promise.resolve(window.soloData);
+  }
+  return fetch('solo-data.json').then(function(r) { return r.json(); });
+}
+
+loadData().then(function(data) {
+    // Render banner
+    const bannerDiv = document.getElementById('bannerContainer');
+    bannerDiv.innerHTML = '<div class="pt-3 mt-4 alert alert-danger" role="alert"><h2>' +
+      escapeHtml(data.bannerText) + ' (Updated: ' + escapeHtml(data.updatedDate) + ')</h2></div>';
+
+    const table = document.getElementById('mainTable');
+
+    // Render Starter section
+    table.appendChild(renderClassThead('Starter'));
+
+    const starterTbody = document.createElement('tbody');
+    starterTbody.className = 'table-group-divider table-light';
+    starterTbody.id = 'tbodyStarter';
+    data.starterBuilds.forEach(function(build) {
+      starterTbody.appendChild(renderStarterRow(build));
+    });
+    table.appendChild(starterTbody);
+
+    // Render class sections
+    const classOrder = ['Sorceress', 'Druid', 'Assassin', 'Barbarian', 'Amazon', 'Necromancer', 'Paladin'];
+    classOrder.forEach(function(cls) {
+      table.appendChild(renderClassThead(cls));
+
+      const tbody = document.createElement('tbody');
+      let tbodyClass = 'table-group-divider ' + classTableStyles[cls];
+      if (cls === 'Paladin') tbodyClass += ' table-light';
+      tbody.className = tbodyClass;
+      tbody.id = 'tbody' + cls;
+
+      const builds = data.classBuilds[cls] || [];
+      builds.forEach(function(build) {
+        tbody.appendChild(renderClassBuildRow(build));
+      });
+      table.appendChild(tbody);
+    });
+
+    // Setup checkbox toggle logic
+    setupCheckboxToggles();
+  });
+
+function setupCheckboxToggles() {
+  const sections = ['Starter', 'Sorceress', 'Druid', 'Assassin', 'Barbarian', 'Amazon', 'Necromancer', 'Paladin'];
+  sections.forEach(function(section) {
+    const checkbox = document.getElementById('checkbox' + section);
+    const tbody = document.getElementById('tbody' + section);
+    const thead = document.getElementById('thead' + section);
+
+    if (checkbox && tbody && thead) {
+      checkbox.addEventListener('change', function() {
+        if (this.checked) {
+          tbody.style.display = '';
+          thead.style.display = '';
+        } else {
+          tbody.style.display = 'none';
+          thead.style.display = 'none';
+        }
+      });
+    }
+  });
+}
+
+const allClassCheckboxes = ['checkboxStarter','checkboxSorceress','checkboxDruid','checkboxAssassin','checkboxBarbarian','checkboxAmazon','checkboxNecromancer','checkboxPaladin'];
+function toggleAll(newState) {
+  allClassCheckboxes.forEach(function(id) {
+    const cb = document.getElementById(id);
+    if (cb.checked !== newState) {
+      cb.checked = newState;
+      cb.dispatchEvent(new Event('change'));
+    }
+  });
+}
+
+const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+const tooltipList = [...tooltipTriggerList].map(function(el) { return new bootstrap.Tooltip(el); });
+
+// ── Wheel of Names ──
+
+const wheelClassColors = {
+  'Sorceress': '#4a86c8', 'Druid': '#5a9e6f', 'Assassin': '#d4944a',
+  'Barbarian': '#c45a5a', 'Amazon': '#4abcd4', 'Necromancer': '#9a7ec0',
+  'Paladin': '#c9b44a'
+};
+
+let wheelEntries = [];
+let wheelAngle = 0;
+let wheelSpinning = false;
+let wheelAnimId = null;
+
+function getVisibleBuilds() {
+  var builds = [];
+  if (!window.soloData) return builds;
+  var classOrder = ['Sorceress','Druid','Assassin','Barbarian','Amazon','Necromancer','Paladin'];
+  classOrder.forEach(function(cls) {
+    var cb = document.getElementById('checkbox' + cls);
+    if (cb && cb.checked) {
+      var clsBuilds = window.soloData.classBuilds[cls] || [];
+      clsBuilds.forEach(function(b) {
+        builds.push({ name: cls + ' - ' + b.buildName, buildName: b.buildName, className: cls });
+      });
+    }
+  });
+  return builds;
+}
+
+function drawWheel() {
+  var canvas = document.getElementById('wheelCanvas');
+  if (!canvas) return;
+  var ctx = canvas.getContext('2d');
+  var cx = canvas.width / 2, cy = canvas.height / 2, r = Math.min(cx, cy) - 15;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  if (wheelEntries.length === 0) {
+    ctx.fillStyle = '#333';
+    ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = '#aaa'; ctx.font = '20px sans-serif'; ctx.textAlign = 'center';
+    ctx.fillText('No builds visible', cx, cy);
+    return;
+  }
+
+  var n = wheelEntries.length;
+  var sliceAngle = (Math.PI * 2) / n;
+
+  for (var i = 0; i < n; i++) {
+    var start = wheelAngle + i * sliceAngle;
+    var end = start + sliceAngle;
+    var baseColor = wheelClassColors[wheelEntries[i].className] || '#666';
+    // alternate brightness for adjacent same-class slices
+    ctx.fillStyle = i % 2 === 0 ? baseColor : shadeColor(baseColor, -25);
+
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.arc(cx, cy, r, start, end);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = '#1a1a1a';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+
+    // text
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.rotate(start + sliceAngle / 2);
+    ctx.fillStyle = '#fff';
+    ctx.shadowColor = 'rgba(0,0,0,0.7)';
+    ctx.shadowBlur = 3;
+    var fontSize = n > 40 ? 8 : n > 25 ? 10 : n > 15 ? 12 : 14;
+    ctx.font = 'bold ' + fontSize + 'px sans-serif';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    var label = wheelEntries[i].buildName;
+    var maxLen = n > 30 ? 20 : 30;
+    if (label.length > maxLen) label = label.substring(0, maxLen - 1) + '\u2026';
+    ctx.fillText(label, r - 10, 0);
+    ctx.restore();
+  }
+
+  // center circle
+  ctx.beginPath(); ctx.arc(cx, cy, 22, 0, Math.PI * 2);
+  ctx.fillStyle = '#1a1a1a'; ctx.fill();
+  ctx.strokeStyle = '#555'; ctx.lineWidth = 2; ctx.stroke();
+}
+
+function shadeColor(hex, percent) {
+  var num = parseInt(hex.replace('#',''), 16);
+  var r = Math.min(255, Math.max(0, (num >> 16) + percent));
+  var g = Math.min(255, Math.max(0, ((num >> 8) & 0xff) + percent));
+  var b = Math.min(255, Math.max(0, (num & 0xff) + percent));
+  return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+}
+
+function openWheelModal() {
+  wheelEntries = getVisibleBuilds();
+  wheelAngle = 0;
+  wheelSpinning = false;
+  if (wheelAnimId) { cancelAnimationFrame(wheelAnimId); wheelAnimId = null; }
+  document.getElementById('wheelResult').textContent = '';
+  document.getElementById('spinBtn').disabled = false;
+  drawWheel();
+  var modal = new bootstrap.Modal(document.getElementById('wheelModal'));
+  modal.show();
+}
+
+function spinWheel() {
+  if (wheelSpinning || wheelEntries.length === 0) return;
+  wheelSpinning = true;
+  document.getElementById('spinBtn').disabled = true;
+  document.getElementById('wheelResult').textContent = '';
+
+  // random total rotation: 5-10 full turns + random offset
+  var totalRotation = (Math.PI * 2) * (5 + Math.random() * 5) + Math.random() * Math.PI * 2;
+  var duration = 4000 + Math.random() * 2000; // 4-6 seconds
+  var startAngle = wheelAngle;
+  var startTime = performance.now();
+
+  function easeOutCubic(t) { return 1 - Math.pow(1 - t, 3); }
+
+  function animate(now) {
+    var elapsed = now - startTime;
+    var t = Math.min(elapsed / duration, 1);
+    var eased = easeOutCubic(t);
+    wheelAngle = startAngle + totalRotation * eased;
+    drawWheel();
+
+    if (t < 1) {
+      // tick sound via subtle visual flash near end
+      wheelAnimId = requestAnimationFrame(animate);
+    } else {
+      wheelSpinning = false;
+      wheelAnimId = null;
+      document.getElementById('spinBtn').disabled = false;
+      announceWinner();
+    }
+  }
+  wheelAnimId = requestAnimationFrame(animate);
+}
+
+function announceWinner() {
+  if (wheelEntries.length === 0) return;
+  var n = wheelEntries.length;
+  var sliceAngle = (Math.PI * 2) / n;
+  // Pointer is at the top of the canvas = -PI/2 radians (or 3*PI/2) in standard canvas coords.
+  // Slice i spans from (wheelAngle + i*sliceAngle) to (wheelAngle + (i+1)*sliceAngle).
+  // We need to find which slice contains the pointer angle (-PI/2).
+  var pointerRad = -Math.PI / 2;
+  // Offset from wheel's rotation start to the pointer
+  var offset = pointerRad - wheelAngle;
+  // Normalize to [0, 2*PI)
+  offset = ((offset % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2);
+  var winnerIndex = Math.floor(offset / sliceAngle) % n;
+  var winner = wheelEntries[winnerIndex];
+
+  var resultEl = document.getElementById('wheelResult');
+  resultEl.innerHTML = '<span class="text-warning">' + escapeHtml(winner.name) + '</span>';
+
+  // brief flash effect
+  resultEl.style.transition = 'none';
+  resultEl.style.textShadow = '0 0 20px gold';
+  setTimeout(function() {
+    resultEl.style.transition = 'text-shadow 1s';
+    resultEl.style.textShadow = 'none';
+  }, 50);
+
+  fireConfetti();
+}
+
+function fireConfetti() {
+  var modal = document.querySelector('#wheelModal .modal-body');
+  var rect = modal.getBoundingClientRect();
+  var particles = [];
+  var colors = ['#ffd700','#ff6b6b','#4ecdc4','#45b7d1','#f9ca24','#6c5ce7','#fd79a8','#00b894','#e17055','#0984e3'];
+  var count = 150;
+
+  for (var i = 0; i < count; i++) {
+    particles.push({
+      x: rect.width / 2,
+      y: rect.height / 2,
+      vx: (Math.random() - 0.5) * 16,
+      vy: (Math.random() - 1) * 14 - 2,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      size: Math.random() * 8 + 3,
+      rotation: Math.random() * 360,
+      rotSpeed: (Math.random() - 0.5) * 12,
+      gravity: 0.15 + Math.random() * 0.1,
+      opacity: 1,
+      shape: Math.random() > 0.5 ? 'rect' : 'circle'
+    });
+  }
+
+  var canvas = document.createElement('canvas');
+  canvas.width = rect.width;
+  canvas.height = rect.height;
+  canvas.style.cssText = 'position:absolute;top:0;left:0;pointer-events:none;z-index:9999;';
+  modal.style.position = 'relative';
+  modal.appendChild(canvas);
+  var ctx = canvas.getContext('2d');
+
+  var startTime = performance.now();
+  var duration = 3000;
+
+  function animateConfetti(now) {
+    var elapsed = now - startTime;
+    if (elapsed > duration) {
+      canvas.remove();
+      return;
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    particles.forEach(function(p) {
+      p.x += p.vx;
+      p.vy += p.gravity;
+      p.y += p.vy;
+      p.vx *= 0.99;
+      p.rotation += p.rotSpeed;
+      if (elapsed > duration * 0.6) {
+        p.opacity = Math.max(0, 1 - (elapsed - duration * 0.6) / (duration * 0.4));
+      }
+
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.rotation * Math.PI / 180);
+      ctx.globalAlpha = p.opacity;
+      ctx.fillStyle = p.color;
+      if (p.shape === 'rect') {
+        ctx.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2);
+      } else {
+        ctx.beginPath();
+        ctx.arc(0, 0, p.size / 2, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.restore();
+    });
+
+    requestAnimationFrame(animateConfetti);
+  }
+  requestAnimationFrame(animateConfetti);
+}
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Extract all solo.html static build data into `solo-data.json` (76 class builds + 24 starter builds across 7 classes), with solo.html now rendering dynamically from the JSON
- Add "Spin the Wheel" canvas modal to both solo.html and group.html — class-colored wheel slices, smooth spin animation, confetti on winner
- Wheel respects active class checkbox filters; group.html also respects group type selection (Generalists/Physical/Elemental)

## Test plan
- [ ] Open solo.html from file:// — verify all builds render with correct class colors, tiers, planner links
- [ ] Toggle class checkboxes on solo.html — verify sections show/hide
- [ ] Click "Spin the Wheel" on solo.html — verify wheel populates with visible builds, spins, announces correct winner with confetti
- [ ] Open group.html — pick each group type radio, verify content displays with correct class formatting
- [ ] Click "Spin the Wheel" on group.html for each group type — verify wheel shows only builds from selected group type and checked classes
- [ ] Verify generalist section has its own spin button visible when Generalists is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)