### PR TITLE
wheel: starter builds + fullscreen confetti

### DIFF
--- a/group.html
+++ b/group.html
@@ -882,7 +882,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		</div>
 
 		<div class="col-sm-6 col-md-3 col-xl-auto d-flex align-items-center">
-			<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127922; Spin the Wheel</button>
+			<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127905; Spin the Wheel</button>
 		</div>
 
 	</div>
@@ -893,7 +893,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 	<div class="modal-dialog modal-dialog-centered modal-lg">
 		<div class="modal-content bg-dark text-white">
 			<div class="modal-header border-secondary">
-				<h5 class="modal-title" id="wheelModalLabel">&#127922; Spin the Wheel</h5>
+				<h5 class="modal-title" id="wheelModalLabel">&#127905; Spin the Wheel</h5>
 				<button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
 			</div>
 			<div class="modal-body text-center p-2">
@@ -913,7 +913,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 <div id="generalists" style="display: none;">
 
 	<div class="text-center my-2">
-		<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127922; Spin the Wheel</button>
+		<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127905; Spin the Wheel</button>
 	</div>
 
 	<div class="alert alert-dark" role="alert">

--- a/solo.html
+++ b/solo.html
@@ -675,7 +675,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		</div>
 
 		<div class="col-sm-6 col-md-3 col-xl-auto d-flex align-items-center">
-			<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127922; Spin the Wheel</button>
+			<button class="btn btn-outline-light btn-sm" onclick="openWheelModal()">&#127905; Spin the Wheel</button>
 		</div>
 
 	</div>
@@ -686,7 +686,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 	<div class="modal-dialog modal-dialog-centered modal-lg">
 		<div class="modal-content bg-dark text-white">
 			<div class="modal-header border-secondary">
-				<h5 class="modal-title" id="wheelModalLabel">&#127922; Spin the Wheel</h5>
+				<h5 class="modal-title" id="wheelModalLabel">&#127905; Spin the Wheel</h5>
 				<button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
 			</div>
 			<div class="modal-body text-center p-2">


### PR DESCRIPTION
## Summary
- Solo wheel now includes starter builds when Starter checkbox is checked (no class checkbox dependency)
- Confetti upgraded on both solo and group pages: 400 particles, fullscreen center-burst explosion, 6 second duration

## Test plan
- [ ] Solo: check only Starter, spin wheel — verify starter builds appear
- [ ] Solo: check Starter + classes — verify no duplicates, both starter-only and class builds show
- [ ] Both pages: spin and win — verify confetti fills entire screen and lasts ~6 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)