### PR TITLE
Add RoboPD2 Planner tile to External Resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,6 +362,15 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 					<p class="card-text">Speed mapping database by Mayswan.</p>
 				</div>
 			</div>
+			<div class="col-md-6 col-lg-4 card">
+				<div class="card-body">
+					<h5 class="card-title"><a target="_blank"
+					                          href="https://robopd2.com/planner"
+					                          class="alert-link">RoboPD2 Planner
+						🔗</a></h5>
+					<p class="card-text">Build planner and character planning tool for Project Diablo 2.</p>
+				</div>
+			</div>
 		</div>
 	</div>
 


### PR DESCRIPTION
## Summary
- Adds a new tile for [RoboPD2 Planner](https://robopd2.com/planner) to the External Resources section on the index page
- Follows the existing card layout pattern used by other external resource tiles

Closes #47

## Test plan
- [ ] Verify the new tile appears in the External Resources section
- [ ] Verify the link opens https://robopd2.com/planner in a new tab
- [ ] Verify card styling matches existing tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)