### PR TITLE
Update cz.html to use TOP/GOOD tags

### DIFF
--- a/cz.html
+++ b/cz.html
@@ -20,7 +20,7 @@
 #zoneFilter{}.filter-check label{cursor:pointer}
 .countdown{font-size:.8rem;color:#6b7280}
 .time-controls{background:#16181b;border:1px solid #2b2f33;border-radius:8px;padding:1rem;margin-bottom:1rem}
-.tag-badge{font-size:.65rem;font-weight:700;border-radius:3px;padding:1px 5px;margin-left:4px}.tag-exp{background:#06b6d4;color:#fff}.tag-mf{background:#eab308;color:#000}.tag-red{background:#ef4444;color:#fff}
+.tag-badge{font-size:.65rem;font-weight:700;border-radius:3px;padding:1px 5px;margin-left:4px}.tag-top{background:#22c55e;color:#fff}.tag-good{background:#3b82f6;color:#fff}.tag-red{background:#ef4444;color:#fff}
 </style></head>
 <body data-bs-theme="dark">
 <div class="container py-4" style="max-width:1000px">
@@ -62,7 +62,7 @@
 <p>Edit <code>config.json</code> in your repo to control which zones send alerts:</p>
 <ul>
 <li><strong>Specific zones:</strong> <code>"FAVORITE_ZONES": "Chaos Sanctuary, Cow Level"</code></li>
-<li><strong>By tag:</strong> <code>"TAG_ZONES": "MF, EXP"</code></li>
+<li><strong>By tag:</strong> <code>"TAG_ZONES": "GOOD, TOP"</code></li>
 <li><strong>Both:</strong> alerts fire when <em>either</em> condition matches</li>
 <li><strong>All zones:</strong> leave both fields empty (the default)</li>
 </ul>
@@ -95,7 +95,7 @@
 <div class="col-md-4"><label class="form-label mb-1">Alignment</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovAlign"><option value="left">Left</option><option value="center">Center</option><option value="right">Right</option></select></div>
 <div class="col-md-4"><label class="form-label mb-1">Scale</label><input type="number" class="form-control form-control-sm bg-dark text-white border-secondary" id="ovScale" value="1" min="0.5" max="3" step="0.1"></div>
 <div class="col-md-4"><label class="form-label mb-1">Show title</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovTitle"><option value="1">Yes</option><option value="0">No</option></select></div>
-<div class="col-md-4"><label class="form-label mb-1">Filter by tags</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovTags"><option value="">All</option><option value="EXP">EXP only</option><option value="MF">MF only</option><option value="RED">RED only</option><option value="EXP,MF">EXP + MF</option><option value="EXP,MF,RED">EXP + MF + RED</option></select></div>
+<div class="col-md-4"><label class="form-label mb-1">Filter by tags</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovTags"><option value="">All</option><option value="TOP">TOP only</option><option value="GOOD">GOOD only</option><option value="RED">RED only</option><option value="TOP,GOOD">TOP + GOOD</option><option value="TOP,GOOD,RED">TOP + GOOD + RED</option></select></div>
 <div class="col-md-4"><label class="form-label mb-1">Mini mode</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovMini"><option value="0">Off</option><option value="1">On</option></select><div class="form-text text-secondary" style="font-size:.75rem">Compact layout, countdown badges, no LIVE/Next labels</div></div>
 </div>
 <h6 class="mb-2">Filter by Act</h6>
@@ -133,7 +133,7 @@
 <tbody>
 <tr><td><code>count</code></td><td>3</td><td>Number of zones to display</td></tr>
 <tr><td><code>acts</code></td><td>all</td><td>Comma-separated acts, e.g. <code>1,3,5</code></td></tr>
-<tr><td><code>tags</code></td><td>all</td><td><code>EXP</code>, <code>MF</code>, <code>RED</code>, or combinations like <code>EXP,MF,RED</code></td></tr>
+<tr><td><code>tags</code></td><td>all</td><td><code>TOP</code>, <code>GOOD</code>, <code>RED</code>, or combinations like <code>TOP,GOOD,RED</code></td></tr>
 <tr><td><code>zones</code></td><td>all</td><td>Comma-separated zone indices (overrides acts/tags)</td></tr>
 <tr><td><code>theme</code></td><td>dark</td><td><code>dark</code> or <code>light</code></td></tr>
 <tr><td><code>align</code></td><td>left</td><td><code>left</code>, <code>center</code>, or <code>right</code></td></tr>
@@ -167,8 +167,8 @@
 <button class="btn btn-sm btn-outline-secondary ms-2" id="btnSelectAll">All</button>
 <button class="btn btn-sm btn-outline-secondary" id="btnSelectNone">None</button>
 <span class="text-secondary ms-3" style="font-size:.85rem">Filter by:</span>
-<button class="btn btn-sm btn-outline-info" id="btnFilterEXP">EXP</button>
-<button class="btn btn-sm btn-outline-warning" id="btnFilterMF">MF</button>
+<button class="btn btn-sm btn-outline-success" id="btnFilterTOP">TOP</button>
+<button class="btn btn-sm btn-outline-primary" id="btnFilterGOOD">GOOD</button>
 <button class="btn btn-sm btn-outline-danger" id="btnFilterRED">RED</button>
 </div></div>
 <div class="mb-3"><button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#zoneFilterCollapse">Filter individual zones &#9662;</button>
@@ -184,8 +184,8 @@
 (function(){
 var zones=window.czData.zones;
 var zoneAct=window.czData.zoneAct;
-var expZones=new Set(window.czData.expZones);
-var mfZones=new Set(window.czData.mfZones);
+var topZones=new Set(window.czData.topZones);
+var goodZones=new Set(window.czData.goodZones);
 var redZones=new Set(window.czData.redZones);
 var getNextPrng=function(seed,mul,inc){return Number(((BigInt(seed)*BigInt(mul)+BigInt(inc))>>BigInt(16))&BigInt(32767))};
 var getZone=function(ts,n){n=n||0;ts=~~(ts/900e3)*900e3;ts+=900e3*n;var a=~~(ts/900000);var b=~~(ts/86400000);var seed=a+b;var idx=getNextPrng(seed,214013,2531011)%zones.length;return{zone:zones[idx],act:zoneAct[idx],ts:ts,seed:seed,idx:idx}};
@@ -202,18 +202,18 @@ var isZoneVisible=function(idx){return activeActs.has(zoneAct[idx])&&activeZones
 var getUpcomingList=function(baseTs,count){var list=[];for(var i=0;list.length<count;i++){var info=getZone(baseTs,i);if(isZoneVisible(info.idx))list.push(info);if(i>500)break}return list};
 var getNextNPerZone=function(baseTs,n){var result={},counts={},vc=0;for(var vi=0;vi<zones.length;vi++){if(isZoneVisible(vi))vc++}var done=false;for(var i=0;!done&&i<2000;i++){var info=getZone(baseTs,i);if(!isZoneVisible(info.idx))continue;if(!result[info.idx]){result[info.idx]=[];counts[info.idx]=0}if(counts[info.idx]<n){result[info.idx].push({ts:info.ts});counts[info.idx]++}if(Object.keys(counts).length>=vc){done=true;for(var k in counts){if(counts[k]<n){done=false;break}}}}return result};
 var mkEl=function(tag,cls,txt){var e=document.createElement(tag);if(cls)e.className=cls;if(txt)e.textContent=txt;return e};
-var mkTags=function(idx){var wrap=mkEl("span","d-flex gap-1");if(expZones.has(idx))wrap.appendChild(mkEl("span","tag-badge tag-exp","EXP"));if(mfZones.has(idx))wrap.appendChild(mkEl("span","tag-badge tag-mf","MF"));if(redZones.has(idx))wrap.appendChild(mkEl("span","tag-badge tag-red","RED"));return wrap};
+var mkTags=function(idx){var wrap=mkEl("span","d-flex gap-1");if(topZones.has(idx))wrap.appendChild(mkEl("span","tag-badge tag-top","TOP"));if(goodZones.has(idx))wrap.appendChild(mkEl("span","tag-badge tag-good","GOOD"));if(redZones.has(idx))wrap.appendChild(mkEl("span","tag-badge tag-red","RED"));return wrap};
 var renderUpcoming=function(){var baseTs=getBaseTs(),now=Date.now(),list=getUpcomingList(baseTs,UPCOMING_COUNT);paneUpcoming.innerHTML="";if(!list.length){paneUpcoming.textContent="No zones match your current filters.";return}for(var i=0;i<list.length;i++){var info=list[i];var isNow=now>=info.ts&&now<info.ts+900e3;var card=mkEl("div","zone-card"+(isNow?" active-now":""));var top=mkEl("div","d-flex justify-content-between align-items-center flex-wrap gap-1");var topLeft=mkEl("div","d-flex align-items-center flex-wrap gap-1");topLeft.appendChild(mkEl("span","act-badge act-"+info.act,"Act "+info.act));topLeft.appendChild(mkEl("span","zone-name",info.zone));top.appendChild(topLeft);top.appendChild(mkTags(info.idx));card.appendChild(top);var bot=mkEl("div","d-flex justify-content-between align-items-center mt-1");bot.appendChild(mkEl("span","zone-time"+(isNow?" now":""),((isNow?"LIVE NOW -- ":"")+formatTime(info.ts))));bot.appendChild(mkEl("span","countdown",formatCountdown(info.ts-now)));card.appendChild(bot);paneUpcoming.appendChild(card)}};
 var renderByZone=function(){var baseTs=getBaseTs(),now=Date.now(),perZone=getNextNPerZone(baseTs,NEXT_COUNT);var si=Object.keys(perZone).map(Number).sort(function(a,b){return perZone[a][0].ts-perZone[b][0].ts});paneByZone.innerHTML="";if(!si.length){paneByZone.textContent="No zones match your current filters.";return}for(var j=0;j<si.length;j++){var idx=si[j];var times=perZone[idx];var isNow=now>=times[0].ts&&now<times[0].ts+900e3;var card=mkEl("div","zone-card"+(isNow?" active-now":""));var top=mkEl("div","d-flex justify-content-between align-items-center flex-wrap gap-1");var topLeft=mkEl("div","d-flex align-items-center flex-wrap gap-1");topLeft.appendChild(mkEl("span","act-badge act-"+zoneAct[idx],"Act "+zoneAct[idx]));topLeft.appendChild(mkEl("span","zone-name",zones[idx]));top.appendChild(topLeft);top.appendChild(mkTags(idx));card.appendChild(top);var ul=mkEl("ul","schedule-times");for(var ti=0;ti<times.length;ti++){var t=times[ti];var live=now>=t.ts&&now<t.ts+900e3;var li=mkEl("li",live?"now-label":"",((live?"LIVE NOW -- ":"")+formatTime(t.ts)));li.appendChild(mkEl("span","countdown"," "+formatCountdown(t.ts-now)));ul.appendChild(li)}card.appendChild(ul);paneByZone.appendChild(card)}};
 var renderAll=function(){renderUpcoming();renderByZone();clockDisplay.textContent=useCustomTime?("Showing: "+new Date(customTs).toLocaleString()):new Date().toLocaleTimeString()};
 var syncActs=function(){activeActs=new Set();activeZones.forEach(function(idx){activeActs.add(zoneAct[idx])});var b=document.querySelectorAll(".filter-btn[data-act]");for(var i=0;i<b.length;i++){var act=parseInt(b[i].dataset.act);if(activeActs.has(act))b[i].classList.add("active");else b[i].classList.remove("active")}};
-var buildZoneFilter=function(){var c=pE("zoneFilter");var row=mkEl("div","row");for(var i=0;i<zones.length;i++){var col=mkEl("div","col-md-6 filter-check");var fc=mkEl("div","form-check");var inp=document.createElement("input");inp.className="form-check-input zone-cb";inp.type="checkbox";inp.id="zcb"+i;inp.dataset.idx=i;inp.checked=activeZones.has(i);var lbl=document.createElement("label");lbl.className="form-check-label";lbl.htmlFor="zcb"+i;lbl.appendChild(mkEl("span","act-badge act-"+zoneAct[i],"A"+zoneAct[i]));lbl.appendChild(document.createTextNode(" "+zones[i]));if(expZones.has(i))lbl.appendChild(mkEl("span","tag-badge tag-exp ms-1","EXP"));if(mfZones.has(i))lbl.appendChild(mkEl("span","tag-badge tag-mf ms-1","MF"));if(redZones.has(i))lbl.appendChild(mkEl("span","tag-badge tag-red ms-1","RED"));fc.appendChild(inp);fc.appendChild(lbl);col.appendChild(fc);row.appendChild(col);(function(cb){cb.addEventListener("change",function(){var x=parseInt(cb.dataset.idx);if(cb.checked)activeZones.add(x);else activeZones.delete(x);syncActs();renderAll()})})(inp)}c.innerHTML="";c.appendChild(row)};
+var buildZoneFilter=function(){var c=pE("zoneFilter");var row=mkEl("div","row");for(var i=0;i<zones.length;i++){var col=mkEl("div","col-md-6 filter-check");var fc=mkEl("div","form-check");var inp=document.createElement("input");inp.className="form-check-input zone-cb";inp.type="checkbox";inp.id="zcb"+i;inp.dataset.idx=i;inp.checked=activeZones.has(i);var lbl=document.createElement("label");lbl.className="form-check-label";lbl.htmlFor="zcb"+i;lbl.appendChild(mkEl("span","act-badge act-"+zoneAct[i],"A"+zoneAct[i]));lbl.appendChild(document.createTextNode(" "+zones[i]));if(topZones.has(i))lbl.appendChild(mkEl("span","tag-badge tag-top ms-1","TOP"));if(goodZones.has(i))lbl.appendChild(mkEl("span","tag-badge tag-good ms-1","GOOD"));if(redZones.has(i))lbl.appendChild(mkEl("span","tag-badge tag-red ms-1","RED"));fc.appendChild(inp);fc.appendChild(lbl);col.appendChild(fc);row.appendChild(col);(function(cb){cb.addEventListener("change",function(){var x=parseInt(cb.dataset.idx);if(cb.checked)activeZones.add(x);else activeZones.delete(x);syncActs();renderAll()})})(inp)}c.innerHTML="";c.appendChild(row)};
 var actBtns=document.querySelectorAll(".filter-btn[data-act]");for(var ai=0;ai<actBtns.length;ai++){(function(btn){btn.addEventListener("click",function(){var act=parseInt(btn.dataset.act);if(activeActs.has(act)){activeActs.delete(act);btn.classList.remove("active")}else{activeActs.add(act);btn.classList.add("active")}for(var i=0;i<zones.length;i++){if(zoneAct[i]===act){if(activeActs.has(act))activeZones.add(i);else activeZones.delete(i);var cb=pE("zcb"+i);if(cb)cb.checked=activeActs.has(act)}}renderAll()})})(actBtns[ai])}
 pE("btnSelectAll").addEventListener("click",function(){activeActs=new Set([1,2,3,4,5]);activeZones=new Set(zones.map(function(_,i){return i}));var b=document.querySelectorAll(".filter-btn[data-act]");for(var i=0;i<b.length;i++)b[i].classList.add("active");var c=document.querySelectorAll(".zone-cb");for(var i=0;i<c.length;i++)c[i].checked=true;renderAll()});
 pE("btnSelectNone").addEventListener("click",function(){activeActs=new Set();activeZones=new Set();var b=document.querySelectorAll(".filter-btn[data-act]");for(var i=0;i<b.length;i++)b[i].classList.remove("active");var c=document.querySelectorAll(".zone-cb");for(var i=0;i<c.length;i++)c[i].checked=false;renderAll()});
 var applyTagFilter=function(tagSet){activeZones=new Set(tagSet);activeActs=new Set();tagSet.forEach(function(idx){activeActs.add(zoneAct[idx])});var b=document.querySelectorAll(".filter-btn[data-act]");for(var i=0;i<b.length;i++){var act=parseInt(b[i].dataset.act);if(activeActs.has(act))b[i].classList.add("active");else b[i].classList.remove("active")}var c=document.querySelectorAll(".zone-cb");for(var i=0;i<c.length;i++){c[i].checked=activeZones.has(parseInt(c[i].dataset.idx))}renderAll()};
-pE("btnFilterEXP").addEventListener("click",function(){applyTagFilter(expZones)});
-pE("btnFilterMF").addEventListener("click",function(){applyTagFilter(mfZones)});
+pE("btnFilterTOP").addEventListener("click",function(){applyTagFilter(topZones)});
+pE("btnFilterGOOD").addEventListener("click",function(){applyTagFilter(goodZones)});
 pE("btnFilterRED").addEventListener("click",function(){applyTagFilter(redZones)});
 var radios=document.querySelectorAll("input[name=timeMode]");for(var ri=0;ri<radios.length;ri++){(function(r){r.addEventListener("change",function(){useCustomTime=r.value==="custom";customTimeWrapper.style.display=useCustomTime?"":"none";if(useCustomTime&&customDateTimeInput.value)customTs=new Date(customDateTimeInput.value).getTime();renderAll()})})(radios[ri])}
 customDateTimeInput.addEventListener("change",function(){customTs=new Date(customDateTimeInput.value).getTime();renderAll()});
@@ -226,8 +226,8 @@ buildZoneFilter();renderAll();setInterval(renderAll,5000);
 (function(){
 var zones=window.czData.zones;
 var zoneAct=window.czData.zoneAct;
-var expZones=new Set(window.czData.expZones);
-var mfZones=new Set(window.czData.mfZones);
+var topZones=new Set(window.czData.topZones);
+var goodZones=new Set(window.czData.goodZones);
 var redZones=new Set(window.czData.redZones);
 var ovSelectedZones=new Set();
 var baseUrl=window.location.href.replace(/cz\.html.*/,"cz-overlay.html");
@@ -238,8 +238,8 @@ var buildZoneCheckboxes=function(){
   for(var i=0;i<zones.length;i++){
     html+='<div class="col-md-6"><div class="form-check"><input class="form-check-input ov-zone-cb" type="checkbox" id="ovz'+i+'" value="'+i+'">';
     html+='<label class="form-check-label" for="ovz'+i+'" style="font-size:.85rem"><span class="act-badge act-'+zoneAct[i]+'">A'+zoneAct[i]+'</span> '+zones[i];
-    if(expZones.has(i))html+=' <span class="tag-badge tag-exp" style="font-size:.6rem;border-radius:3px;padding:1px 4px;background:#06b6d4;color:#fff">EXP</span>';
-    if(mfZones.has(i))html+=' <span class="tag-badge tag-mf" style="font-size:.6rem;border-radius:3px;padding:1px 4px;background:#eab308;color:#000">MF</span>';
+    if(topZones.has(i))html+=' <span class="tag-badge tag-top" style="font-size:.6rem;border-radius:3px;padding:1px 4px;background:#22c55e;color:#fff">TOP</span>';
+    if(goodZones.has(i))html+=' <span class="tag-badge tag-good" style="font-size:.6rem;border-radius:3px;padding:1px 4px;background:#3b82f6;color:#fff">GOOD</span>';
     if(redZones.has(i))html+=' <span class="tag-badge tag-red" style="font-size:.6rem;border-radius:3px;padding:1px 4px;background:#ef4444;color:#fff">RED</span>';
     html+='</label></div></div>';
   }


### PR DESCRIPTION
Follow-up to PR #52 — applies the same EXP/MF → TOP/GOOD tag changes to cz.html (which was missed in the original PR).

## Changes
- CSS: `.tag-exp` → `.tag-top` (green `#22c55e`), `.tag-mf` → `.tag-good` (blue `#3b82f6`)
- HTML filter buttons: EXP → TOP, MF → GOOD (with matching button colors)
- OBS overlay dropdown: EXP/MF options → TOP/GOOD
- URL parameters table: updated tag examples
- JS (both script blocks): `expZones`/`mfZones` → `topZones`/`goodZones`, tag rendering, filter handlers
- Overlay configurator: same updates with inline styles
- Discord modal example: updated `TAG_ZONES`
- RED tag left intact throughout

Closes #51

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>