### PR TITLE
Fix #58: Add report issue button to cz.html

### DIFF
--- a/cz.html
+++ b/cz.html
@@ -26,7 +26,16 @@
 <div class="container py-4" style="max-width:1000px">
 <div class="text-center mb-4"><h3 class="mb-0">PD2 Corrupted Zone Schedule</h3>
 <small class="text-secondary">See when each corrupted zone goes live. Zones rotate every 15 minutes.</small>
-<div class="mt-2"><a href="index.html" class="btn btn-sm btn-outline-secondary">&#8592; View other resources</a> <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#notifModal">&#128276; Setup Notifications</button> <button class="btn btn-sm btn-outline-success" data-bs-toggle="modal" data-bs-target="#overlayModal">&#127909; OBS Overlay</button></div></div>
+<div class="mt-2"><a href="index.html" class="btn btn-sm btn-outline-secondary">&#8592; View other resources</a> <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#notifModal">&#128276; Setup Notifications</button> <button class="btn btn-sm btn-outline-success" data-bs-toggle="modal" data-bs-target="#overlayModal">&#127909; OBS Overlay</button> <a id="report-issue-btn" href="https://github.com/Maaaaaarrk/Hiim-PD2-Resources/issues/new?title=cz%3A+&body=%23%23+Issue+Description%0A%0A**Expected%3A**%0A%0A**Actual%3A**%0A%0A**Steps+to+reproduce%3A**%0A%0A**URL+%28with+your+inputs%29%3A**%0A" target="_blank" rel="noopener" class="btn btn-sm btn-outline-danger">&#9888; Report an Issue</a></div></div>
+<script>
+(function(){
+	var btn=document.getElementById('report-issue-btn');
+	if(!btn)return;
+	var base=btn.href.split('body=')[0]+'body=';
+	var body=decodeURIComponent(btn.href.split('body=')[1]);
+	btn.href=base+encodeURIComponent(body+window.location.href);
+})();
+</script>
 <div class="modal fade" id="notifModal" tabindex="-1" aria-labelledby="notifModalLabel" aria-hidden="true">
 <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
 <div class="modal-content bg-dark text-white">


### PR DESCRIPTION
## Summary
- Adds a "Report an Issue" button to the cz.html page header, matching the pattern used on dmg-calc.html and attackspeedcalc.html
- Button pre-fills the GitHub issue template with the page name and appends the current URL for context

Closes #58

## Test plan
- [ ] Open cz.html and verify the "Report an Issue" button appears in the header alongside existing buttons
- [ ] Click the button and confirm it opens a new GitHub issue with the correct title prefix (`cz:`) and pre-filled body template
- [ ] Verify the current page URL is appended to the issue body

🤖 Generated with [Claude Code](https://claude.com/claude-code)