### PR TITLE
Update Warcry Barb to Good tier with clear link

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1006,8 +1006,14 @@ window.soloData = {
     "Barbarian": [
       {
         "buildName": "Warcry",
-        "tier": "Decent",
-        "links": [],
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://streamable.com/cq8k8s",
+            "label": "Sewers of Harrogath (3:00)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {

--- a/solo-data.json
+++ b/solo-data.json
@@ -1006,8 +1006,14 @@
     "Barbarian": [
       {
         "buildName": "Warcry",
-        "tier": "Decent",
-        "links": [],
+        "tier": "Good",
+        "links": [
+          {
+            "url": "https://streamable.com/cq8k8s",
+            "label": "Sewers of Harrogath (3:00)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {


### PR DESCRIPTION
## Summary
- Updated Warcry Barbarian tier from **Decent** to **Good** in the Solo tier list
- Added Sewers of Harrogath (3:00) clear video link: https://streamable.com/cq8k8s
- Updated both `solo-data.js` and `solo-data.json`

Closes #62

## Test plan
- [ ] Verify the Solo tier list page renders correctly
- [ ] Confirm Warcry Barb shows as "Good" tier under Barbarian
- [ ] Confirm the Sewers of Harrogath clear video link button appears and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)