### PR TITLE
Feat: Add configurable sound notifications for zone rotations

### DIFF
--- a/cz-overlay.html
+++ b/cz-overlay.html
@@ -16,6 +16,7 @@
  * scale  = font scale multiplier, e.g. 1.2 (default: 1)
  * title  = 0 to hide the header row (default: 1)
  * zones  = comma-separated zone indices to show (default: all)
+ * sound  = 1 to enable sound notification when a new zone rotation starts (default: off)
  * mini   = 1 to enable minified mode — compact layout, no LIVE/Next labels,
  *          countdown badges (green=active, yellow=starting soon), zone names truncated at 140px
  *
@@ -170,6 +171,8 @@ var align=params.get("align")||"left";
 var scale=parseFloat(params.get("scale"))||1;
 var showTitle=params.get("title")!=="0";
 var mini=params.get("mini")==="1";
+var soundEnabled=params.get("sound")==="1";
+var lastZoneTs=null;
 
 if(mini)document.body.classList.add("mini");
 if(theme==="light")document.body.classList.add("theme-light");
@@ -246,7 +249,40 @@ var render=function(){
   overlay.innerHTML=html;
 };
 render();
-setInterval(render,1000);
+
+// --- Sound notification for zone rotations ---
+var playNotificationSound = function() {
+  try {
+    var ctx = new (window.AudioContext || window.webkitAudioContext)();
+    var playTone = function(freq, start, duration) {
+      var osc = ctx.createOscillator();
+      var gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.frequency.value = freq;
+      osc.type = 'sine';
+      gain.gain.setValueAtTime(0.3, ctx.currentTime + start);
+      gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + start + duration);
+      osc.start(ctx.currentTime + start);
+      osc.stop(ctx.currentTime + start + duration);
+    };
+    playTone(523.25, 0, 0.15);
+    playTone(659.25, 0.15, 0.15);
+    playTone(783.99, 0.3, 0.3);
+  } catch (e) { /* AudioContext not available */ }
+};
+
+setInterval(function() {
+  render();
+  if (!soundEnabled) return;
+  var now = Date.now();
+  var currentZoneTs = Math.floor(now / 900000) * 900000;
+  if (lastZoneTs === null) { lastZoneTs = currentZoneTs; return; }
+  if (currentZoneTs !== lastZoneTs) {
+    lastZoneTs = currentZoneTs;
+    playNotificationSound();
+  }
+}, 1000);
 })();
 </script>
 </body>

--- a/cz.html
+++ b/cz.html
@@ -26,7 +26,7 @@
 <div class="container py-4" style="max-width:1000px">
 <div class="text-center mb-4"><h3 class="mb-0">PD2 Corrupted Zone Schedule</h3>
 <small class="text-secondary">See when each corrupted zone goes live. Zones rotate every 15 minutes.</small>
-<div class="mt-2"><a href="index.html" class="btn btn-sm btn-outline-secondary">&#8592; View other resources</a> <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#notifModal">&#128276; Setup Notifications</button> <button class="btn btn-sm btn-outline-success" data-bs-toggle="modal" data-bs-target="#overlayModal">&#127909; OBS Overlay</button> <a id="report-issue-btn" href="https://github.com/Maaaaaarrk/Hiim-PD2-Resources/issues/new?title=cz%3A+&body=%23%23+Issue+Description%0A%0A**Expected%3A**%0A%0A**Actual%3A**%0A%0A**Steps+to+reproduce%3A**%0A%0A**URL+%28with+your+inputs%29%3A**%0A" target="_blank" rel="noopener" class="btn btn-sm btn-outline-danger">&#9888; Report an Issue</a></div></div>
+<div class="mt-2"><a href="index.html" class="btn btn-sm btn-outline-secondary">&#8592; View other resources</a> <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#notifModal">&#128276; Setup Notifications</button> <button class="btn btn-sm btn-outline-success" data-bs-toggle="modal" data-bs-target="#overlayModal">&#127909; OBS Overlay</button> <button class="btn btn-sm btn-outline-warning" id="btnSoundToggle" title="Play a sound when a new zone rotation starts">&#128264; Sound: OFF</button> <a id="report-issue-btn" href="https://github.com/Maaaaaarrk/Hiim-PD2-Resources/issues/new?title=cz%3A+&body=%23%23+Issue+Description%0A%0A**Expected%3A**%0A%0A**Actual%3A**%0A%0A**Steps+to+reproduce%3A**%0A%0A**URL+%28with+your+inputs%29%3A**%0A" target="_blank" rel="noopener" class="btn btn-sm btn-outline-danger">&#9888; Report an Issue</a></div></div>
 <script>
 (function(){
 	var btn=document.getElementById('report-issue-btn');
@@ -106,6 +106,7 @@
 <div class="col-md-4"><label class="form-label mb-1">Show title</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovTitle"><option value="1">Yes</option><option value="0">No</option></select></div>
 <div class="col-md-4"><label class="form-label mb-1">Filter by tags</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovTags"><option value="">All</option><option value="TOP">TOP only</option><option value="GOOD">GOOD only</option><option value="RED">RED only</option><option value="TOP,GOOD">TOP + GOOD</option><option value="TOP,GOOD,RED">TOP + GOOD + RED</option></select></div>
 <div class="col-md-4"><label class="form-label mb-1">Mini mode</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovMini"><option value="0">Off</option><option value="1">On</option></select><div class="form-text text-secondary" style="font-size:.75rem">Compact layout, countdown badges, no LIVE/Next labels</div></div>
+<div class="col-md-4"><label class="form-label mb-1">Sound notification</label><select class="form-select form-select-sm bg-dark text-white border-secondary" id="ovSound"><option value="0">Off</option><option value="1">On</option></select><div class="form-text text-secondary" style="font-size:.75rem">Play a sound when a new zone rotation starts</div></div>
 </div>
 <h6 class="mb-2">Filter by Act</h6>
 <div class="d-flex flex-wrap gap-2 mb-3">
@@ -149,6 +150,7 @@
 <tr><td><code>scale</code></td><td>1</td><td>Font scale multiplier (e.g. <code>1.3</code>)</td></tr>
 <tr><td><code>title</code></td><td>1</td><td><code>0</code> to hide the header</td></tr>
 <tr><td><code>mini</code></td><td>0</td><td><code>1</code> for compact mode &mdash; less padding, no LIVE/Next labels, countdown badges (green when active, yellow when next zone starts in &lt;5 min), zone names truncated at 140px</td></tr>
+<tr><td><code>sound</code></td><td>0</td><td><code>1</code> to play a sound notification when a new zone rotation starts</td></tr>
 </tbody></table></div>
 </div>
 <div class="modal-footer border-secondary">
@@ -276,6 +278,63 @@ restoreFromHash();buildZoneFilter();renderAll();setInterval(renderAll,5000);
 var tabEls=document.querySelectorAll('button[data-bs-toggle="tab"]');for(var ti=0;ti<tabEls.length;ti++){tabEls[ti].addEventListener('shown.bs.tab',function(){updateHash()})}
 // Listen for hashchange (back/forward)
 window.addEventListener('hashchange',function(){restoreFromHash();buildZoneFilter();renderAll()});
+
+// --- Sound notification for zone rotations ---
+var soundEnabled = localStorage.getItem('czSoundEnabled') === 'true';
+var lastZoneTs = null;
+var soundBtn = document.getElementById('btnSoundToggle');
+
+var updateSoundBtn = function() {
+  if (soundEnabled) {
+    soundBtn.innerHTML = '&#128266; Sound: ON';
+    soundBtn.classList.remove('btn-outline-warning');
+    soundBtn.classList.add('btn-warning');
+  } else {
+    soundBtn.innerHTML = '&#128264; Sound: OFF';
+    soundBtn.classList.remove('btn-warning');
+    soundBtn.classList.add('btn-outline-warning');
+  }
+};
+updateSoundBtn();
+
+soundBtn.addEventListener('click', function() {
+  soundEnabled = !soundEnabled;
+  localStorage.setItem('czSoundEnabled', String(soundEnabled));
+  updateSoundBtn();
+});
+
+var playNotificationSound = function() {
+  try {
+    var ctx = new (window.AudioContext || window.webkitAudioContext)();
+    var playTone = function(freq, start, duration) {
+      var osc = ctx.createOscillator();
+      var gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.frequency.value = freq;
+      osc.type = 'sine';
+      gain.gain.setValueAtTime(0.3, ctx.currentTime + start);
+      gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + start + duration);
+      osc.start(ctx.currentTime + start);
+      osc.stop(ctx.currentTime + start + duration);
+    };
+    playTone(523.25, 0, 0.15);
+    playTone(659.25, 0.15, 0.15);
+    playTone(783.99, 0.3, 0.3);
+  } catch (e) { /* AudioContext not available */ }
+};
+
+// Check for zone rotation every second
+setInterval(function() {
+  if (!soundEnabled || useCustomTime) return;
+  var now = Date.now();
+  var currentZoneTs = Math.floor(now / 900000) * 900000;
+  if (lastZoneTs === null) { lastZoneTs = currentZoneTs; return; }
+  if (currentZoneTs !== lastZoneTs) {
+    lastZoneTs = currentZoneTs;
+    playNotificationSound();
+  }
+}, 1000);
 })();
 </script>
 <script>
@@ -323,6 +382,8 @@ var updateOverlayUrl=function(){
   if(title==="0")p.push("title=0");
   var mini=document.getElementById("ovMini").value;
   if(mini==="1")p.push("mini=1");
+  var sound=document.getElementById("ovSound").value;
+  if(sound==="1")p.push("sound=1");
   var tags=document.getElementById("ovTags").value;
 
   if(ovSelectedZones.size>0){
@@ -351,6 +412,7 @@ document.getElementById("ovScale").addEventListener("input",updateOverlayUrl);
 document.getElementById("ovTitle").addEventListener("change",updateOverlayUrl);
 document.getElementById("ovTags").addEventListener("change",updateOverlayUrl);
 document.getElementById("ovMini").addEventListener("change",updateOverlayUrl);
+document.getElementById("ovSound").addEventListener("change",updateOverlayUrl);
 var actCbs=document.querySelectorAll(".ov-act-cb");
 for(var i=0;i<actCbs.length;i++){actCbs[i].addEventListener("change",updateOverlayUrl)}
 


### PR DESCRIPTION
## Summary
- Adds sound notifications that play a short 3-tone chime when a new corrupted zone rotation starts (every 15 minutes)
- **cz.html**: Toggle button in the header bar (default OFF), preference saved to localStorage
- **cz-overlay.html**: New `sound=1` URL parameter to enable sound (default off), integrated into the OBS overlay URL builder in the modal
- Added `sound` parameter to the overlay configuration UI and the URL parameters reference table

## How it works
- A 1-second interval checks if the current 15-minute zone window has changed
- When a new rotation is detected, a 3-note ascending chime plays using the Web Audio API (no external audio files needed)
- On cz.html, the setting persists across page reloads via localStorage
- On cz-overlay.html, sound is controlled via the `sound=1` query parameter
- Sound is disabled when viewing custom/historical times (cz.html only)

Closes #65

## Test plan
- [ ] Open cz.html, verify Sound button shows "Sound: OFF" by default
- [ ] Click the Sound button, verify it toggles to "Sound: ON" (yellow)
- [ ] Refresh the page, verify the setting persists
- [ ] Wait for a zone rotation (or test by temporarily shortening the interval) to hear the chime
- [ ] Open cz-overlay.html?sound=1 and verify sound plays on rotation
- [ ] Open cz-overlay.html (no param) and verify no sound plays
- [ ] In the OBS Overlay modal, verify the Sound notification dropdown appears and updates the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)