### PR TITLE
Add all missing builds to solo builds list

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -632,6 +632,36 @@ window.soloData = {
           }
         ],
         "notes": []
+      },
+      {
+        "buildName": "Inferno",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Bear",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Lightning Bear",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Cold Bow Sorc",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ],
     "Druid": [
@@ -746,6 +776,30 @@ window.soloData = {
             "type": "planner"
           }
         ],
+        "notes": []
+      },
+      {
+        "buildName": "Wind Innocence Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Pure Poison Creeper",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Thorns Pacifist Druid",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Maul",
+        "tier": "Not Rated",
+        "links": [],
         "notes": []
       }
     ],
@@ -1001,6 +1055,48 @@ window.soloData = {
           }
         ],
         "notes": []
+      },
+      {
+        "buildName": "Death Sentry (A2 Viperfork merc)",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blade Fury Meme Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Fists of Fire",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Tiger Strike",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Claw",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Talon",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Pure Shadow Master Summoner",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ],
     "Barbarian": [
@@ -1131,6 +1227,78 @@ window.soloData = {
             "type": "guide"
           }
         ],
+        "notes": []
+      },
+      {
+        "buildName": "Berserk",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Frenzy",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Concentrate",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Bash",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Split Throw",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Bow Barb",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dual Wield WW (Bleed)",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Throw (Bleed)",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Wolf Barb",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Eternity Barb",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Fend",
+        "tier": "Not Rated",
+        "links": [],
         "notes": []
       }
     ],
@@ -1344,6 +1512,12 @@ window.soloData = {
         "notes": [
           "Loyalty RW & Amp merc"
         ]
+      },
+      {
+        "buildName": "Physical Bear",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ],
     "Necromancer": [
@@ -1512,6 +1686,48 @@ window.soloData = {
           }
         ],
         "notes": []
+      },
+      {
+        "buildName": "Innocence Brand Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Pure Clay/Blood",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Physical Summoner",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Bonehew Bear Bone Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Walking Bear Brand Bone Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Tricurse Skelemancer",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Grim's Magemancer",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ],
     "Paladin": [
@@ -1678,7 +1894,91 @@ window.soloData = {
         "tier": "Decent",
         "links": [],
         "notes": []
+      },
+      {
+        "buildName": "Holy Fire Charge",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Shock Charge",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Freeze Charge",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Fire Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Shock Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Smite",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blessed Hammer Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Sanctuary Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Fire Sacrifice",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Fire Beardin",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Freeze Beardin",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Shock Beardin",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Thorns",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Bow Paladin",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ]
   }
-}
+};

--- a/solo-data.json
+++ b/solo-data.json
@@ -632,6 +632,36 @@
           }
         ],
         "notes": []
+      },
+      {
+        "buildName": "Inferno",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Fire Bear",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Lightning Bear",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Cold Bow Sorc",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ],
     "Druid": [
@@ -746,6 +776,30 @@
             "type": "planner"
           }
         ],
+        "notes": []
+      },
+      {
+        "buildName": "Wind Innocence Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Pure Poison Creeper",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Thorns Pacifist Druid",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Maul",
+        "tier": "Not Rated",
+        "links": [],
         "notes": []
       }
     ],
@@ -1001,6 +1055,48 @@
           }
         ],
         "notes": []
+      },
+      {
+        "buildName": "Death Sentry (A2 Viperfork merc)",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blade Fury Meme Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Fists of Fire",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Tiger Strike",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Claw",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dragon Talon",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Pure Shadow Master Summoner",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ],
     "Barbarian": [
@@ -1131,6 +1227,78 @@
             "type": "guide"
           }
         ],
+        "notes": []
+      },
+      {
+        "buildName": "Berserk",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Frenzy",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Concentrate",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Bash",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Split Throw",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Bow Barb",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Dual Wield WW (Bleed)",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Throw (Bleed)",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Wolf Barb",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Eternity Barb",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Fend",
+        "tier": "Not Rated",
+        "links": [],
         "notes": []
       }
     ],
@@ -1344,6 +1512,12 @@
         "notes": [
           "Loyalty RW & Amp merc"
         ]
+      },
+      {
+        "buildName": "Physical Bear",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ],
     "Necromancer": [
@@ -1512,6 +1686,48 @@
           }
         ],
         "notes": []
+      },
+      {
+        "buildName": "Innocence Brand Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Pure Clay/Blood",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Physical Summoner",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Bonehew Bear Bone Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Walking Bear Brand Bone Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Tricurse Skelemancer",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Grim's Magemancer",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
       }
     ],
     "Paladin": [
@@ -1676,6 +1892,90 @@
       {
         "buildName": "Physical Charge (2-H)",
         "tier": "Decent",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Fire Charge",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Shock Charge",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Freeze Charge",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Fire Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Shock Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Smite",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Blessed Hammer Procs",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Sanctuary Zeal",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Fire Sacrifice",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Fire Beardin",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Freeze Beardin",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Holy Shock Beardin",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Thorns",
+        "tier": "Not Rated",
+        "links": [],
+        "notes": []
+      },
+      {
+        "buildName": "Bow Paladin",
+        "tier": "Not Rated",
         "links": [],
         "notes": []
       }

--- a/solo.html
+++ b/solo.html
@@ -832,7 +832,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 	  return tr;
 	}
 
-	function renderClassBuildRow(build) {
+	function renderClassBuildRow(build, className) {
 	  const tr = document.createElement('tr');
 
 	  const tdName = document.createElement('td');
@@ -852,9 +852,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 	  tdLinks.className = 'align-middle';
 	  tdLinks.colSpan = 5;
 
-	  if (build.links.length === 0 && build.notes.length === 0) {
-		tdLinks.textContent = '-';
-	  } else {
+	  {
 		let linksHtml = '';
 		build.links.forEach(function(link) {
 		  if (link.type === 'planner') {
@@ -868,6 +866,10 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		build.notes.forEach(function(note) {
 		  linksHtml += '<span class="badge rounded-pill text-bg-secondary">' + escapeHtml(note) + '</span>\n';
 		});
+		var submitTitle = encodeURIComponent(className + ' - ' + build.buildName + ' Map Clear');
+		var submitBody = encodeURIComponent('Build: ' + className + ' - ' + build.buildName + '\nMap: \nClear Time: \nNotes: ');
+		var submitUrl = 'https://github.com/Maaaaaarrk/Hiim-PD2-Resources/issues/new?title=' + submitTitle + '&body=' + submitBody;
+		linksHtml += '<a target="_blank" href="' + submitUrl + '" class="btn btn-outline-success btn-sm ms-1" style="font-size:0.65em;padding:2px 6px;">Submit Map Clear</a>\n';
 		tdLinks.innerHTML = linksHtml;
 	  }
 	  tr.appendChild(tdLinks);
@@ -947,7 +949,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		  const builds = data.classBuilds[cls] || [];
 		  builds.forEach(function(build) {
-			tbody.appendChild(renderClassBuildRow(build));
+			tbody.appendChild(renderClassBuildRow(build, cls));
 		  });
 		  table.appendChild(tbody);
 		});


### PR DESCRIPTION
## Summary
Closes #71

- Added **50 new builds** across all 7 classes with tier "Not Rated" to `solo-data.json` and `solo-data.js`
- Added a **"Submit Map Clear" button** to every build row in `solo.html` that opens a pre-filled GitHub issue with the build name
- Carefully compared the issue's build list against existing builds to avoid duplicates (many issue names map to existing builds with different naming)

### New builds by class:
| Class | Count | Builds |
|-------|-------|--------|
| Amazon | 1 | Physical Bear |
| Assassin | 7 | Death Sentry (A2 Viperfork merc), Blade Fury Meme Procs, Fists of Fire, Tiger Strike, Dragon Claw, Dragon Talon, Pure Shadow Master Summoner |
| Barbarian | 12 | Berserk, Frenzy, Concentrate, Bash, Split Throw, Bow Barb, Dual Wield WW (Bleed), Throw (Bleed), Wolf Barb, Eternity Barb, Zeal, Fend |
| Druid | 4 | Wind Innocence Procs, Pure Poison Creeper, Thorns Pacifist Druid, Maul |
| Necromancer | 7 | Innocence Brand Procs, Pure Clay/Blood, Physical Summoner, Bonehew Bear Bone Procs, Walking Bear Brand Bone Procs, Tricurse Skelemancer, Grim's Magemancer |
| Paladin | 14 | Holy Fire/Shock/Freeze Charge, Holy Fire/Shock Zeal, Smite, Blessed Hammer Procs, Sanctuary Zeal, Holy Fire Sacrifice, Holy Fire/Freeze/Shock Beardin, Thorns, Bow Paladin |
| Sorceress | 5 | Inferno, Fire Bear, Lightning Bear, Cold Bow Sorc, Zeal |

## Test plan
- [ ] Verify solo.html loads correctly and all builds display
- [ ] Confirm new builds show with "Not Rated" tier badge (gray)
- [ ] Click "Submit Map Clear" button on any build and verify the GitHub issue form pre-fills with the correct build name
- [ ] Verify existing builds with data (links, videos, planners) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)