### PR TITLE
Fix #72: Make back button prominent on solo/bossing/group pages

### DIFF
--- a/boss.html
+++ b/boss.html
@@ -112,6 +112,31 @@
 		    color: var(--bs-table-color);
 		    border-color: var(--bs-table-border-color);
 		}
+		.back-btn-fixed {
+			position: fixed;
+			top: 12px;
+			left: 12px;
+			z-index: 1050;
+			background: #212529;
+			border: 2px solid #6c757d;
+			border-radius: 8px;
+			padding: 6px 14px;
+			color: #fff;
+			text-decoration: none;
+			font-size: 1rem;
+			font-weight: 600;
+			display: flex;
+			align-items: center;
+			gap: 6px;
+			box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+			transition: background 0.2s, border-color 0.2s;
+		}
+		.back-btn-fixed:hover {
+			background: #343a40;
+			border-color: #adb5bd;
+			color: #fff;
+			text-decoration: none;
+		}
 	</style>
 	<script crossorigin="anonymous"
 	        integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
@@ -119,6 +144,8 @@
 	</script>
 </head>
 <body data-bs-theme="dark">
+<a href="index.html" class="back-btn-fixed" title="Back to Home">&larr; Back</a>
+
 
 <table class="table table-striped table-dark">
 	<tbody>

--- a/group.html
+++ b/group.html
@@ -124,6 +124,31 @@
 		.map-times-toggle .btn-check:checked + .btn {
 			font-weight: bold;
 		}
+		.back-btn-fixed {
+			position: fixed;
+			top: 12px;
+			left: 12px;
+			z-index: 1050;
+			background: #212529;
+			border: 2px solid #6c757d;
+			border-radius: 8px;
+			padding: 6px 14px;
+			color: #fff;
+			text-decoration: none;
+			font-size: 1rem;
+			font-weight: 600;
+			display: flex;
+			align-items: center;
+			gap: 6px;
+			box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+			transition: background 0.2s, border-color 0.2s;
+		}
+		.back-btn-fixed:hover {
+			background: #343a40;
+			border-color: #adb5bd;
+			color: #fff;
+			text-decoration: none;
+		}
 	</style>
 	<script crossorigin="anonymous"
 	        integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
@@ -131,6 +156,8 @@
 	</script>
 </head>
 <body data-bs-theme="dark">
+<a href="index.html" class="back-btn-fixed" title="Back to Home">&larr; Back</a>
+
 
 <table class="table table-striped table-dark">
 	<tbody>

--- a/solo.html
+++ b/solo.html
@@ -130,6 +130,31 @@
 			transform: scale(1.1);
 			transition: all 0.15s ease;
 		}
+		.back-btn-fixed {
+			position: fixed;
+			top: 12px;
+			left: 12px;
+			z-index: 1050;
+			background: #212529;
+			border: 2px solid #6c757d;
+			border-radius: 8px;
+			padding: 6px 14px;
+			color: #fff;
+			text-decoration: none;
+			font-size: 1rem;
+			font-weight: 600;
+			display: flex;
+			align-items: center;
+			gap: 6px;
+			box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+			transition: background 0.2s, border-color 0.2s;
+		}
+		.back-btn-fixed:hover {
+			background: #343a40;
+			border-color: #adb5bd;
+			color: #fff;
+			text-decoration: none;
+		}
 	</style>
 	<script crossorigin="anonymous"
 	        integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
@@ -137,6 +162,8 @@
 	</script>
 </head>
 <body data-bs-theme="dark">
+<a href="index.html" class="back-btn-fixed" title="Back to Home">&larr; Back</a>
+
 
 <table class="table table-striped table-dark">
 	<tbody>


### PR DESCRIPTION
## Summary
- Adds a fixed-position "Back" button in the top-left corner of `solo.html`, `boss.html`, and `group.html`
- The button stays visible while scrolling (position: fixed, z-index: 1050) so it never gets lost among other UI elements
- Styled with a dark background, border, and box shadow to stand out clearly from the page content

Closes #72

## Test plan
- [ ] Open solo.html, boss.html, and group.html in a browser
- [ ] Verify the back button is visible in the top-left corner on all three pages
- [ ] Scroll down and confirm the button stays fixed in position
- [ ] Click the button and confirm it navigates to index.html
- [ ] Check that the button does not overlap important content on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)