### PR TITLE
Fix syntax error in solo.html video badge

### DIFF
--- a/solo.html
+++ b/solo.html
@@ -798,8 +798,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		tagsHtml += '<span class="badge ' + pill + 'text-bg-' + tag.style + '">' + escapeHtml(tag.text) + '</span>\n';
 	  });
 	  if (build.videoUrl) {
-		tagsHtml += '<a target="_blank" href="' + build.videoUrl + '"><span class="badge rounded-pill text-bg-success" style="font-size:0.55em;line-height:1.3">Video<br/>Build Guide</span></a>
-';
+		tagsHtml += '<a target="_blank" href="' + build.videoUrl + '"><span class="badge rounded-pill text-bg-success" style="font-size:0.55em;line-height:1.3">Video<br/>Build Guide</span></a>';
 	  }
 	  tdTags.innerHTML = tagsHtml;
 	  tr.appendChild(tdTags);


### PR DESCRIPTION
## Summary
- Fixes a JavaScript SyntaxError caused by a raw newline inside a string literal in the video badge code added in PR #81
- This was preventing the entire script from parsing, which also broke `openWheelModal`

## Test plan
- [ ] Open solo.html in browser — no console errors
- [ ] Verify video badges appear on Assassin builds
- [ ] Verify "Spin the Wheel" button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)