### PR TITLE
Add video links to Paladin builds in solo.html

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -437,7 +437,8 @@ window.soloData = {
           "text": "Uber Tristram",
           "style": "dark"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=VwH8rsODV-Q"
     },
     {
       "className": "Paladin",
@@ -1799,6 +1800,11 @@ window.soloData = {
             "url": "https://youtu.be/bEdCK4SNh4A",
             "label": "Tomb of Zoltun Kulle (3:09)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=1648s",
+            "label": "Build Guide (27:28)",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1845,6 +1851,11 @@ window.soloData = {
           {
             "url": "https://www.youtube.com/watch?v=hSCvD8sqr4M",
             "label": "Fall of Caldeum (3:27)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=2587s",
+            "label": "Build Guide (43:07)",
             "type": "video"
           }
         ],
@@ -1938,7 +1949,13 @@ window.soloData = {
       {
         "buildName": "Holy Fire Sacrifice",
         "tier": "Not Rated",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=1648s",
+            "label": "Build Guide (27:28)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {

--- a/solo-data.json
+++ b/solo-data.json
@@ -437,7 +437,8 @@
           "text": "Uber Tristram",
           "style": "dark"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=VwH8rsODV-Q"
     },
     {
       "className": "Paladin",
@@ -1799,6 +1800,11 @@
             "url": "https://youtu.be/bEdCK4SNh4A",
             "label": "Tomb of Zoltun Kulle (3:09)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=1648s",
+            "label": "Build Guide (27:28)",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1845,6 +1851,11 @@
           {
             "url": "https://www.youtube.com/watch?v=hSCvD8sqr4M",
             "label": "Fall of Caldeum (3:27)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=2587s",
+            "label": "Build Guide (43:07)",
             "type": "video"
           }
         ],
@@ -1938,7 +1949,13 @@
       {
         "buildName": "Holy Fire Sacrifice",
         "tier": "Not Rated",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=1648s",
+            "label": "Build Guide (27:28)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {


### PR DESCRIPTION
## Summary
- Added video build guide link (`https://www.youtube.com/watch?v=VwH8rsODV-Q`) to the Paladin Holy Bolt / FOH starter build
- Added timestamped video link (27:28) to the Light Sacrifice and Holy Fire Sacrifice endgame builds
- Added timestamped video link (43:07) to the Sanctuary Sacrifice endgame build
- Updated both `solo-data.js` and `solo-data.json`

Closes #88

## Test plan
- [ ] Verify the video badge appears on the Holy Bolt / FOH starter build row
- [ ] Verify the video links appear on the Light Sacrifice, Holy Fire Sacrifice, and Sanctuary Sacrifice endgame build rows
- [ ] Verify all video links open the correct YouTube video at the correct timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)