### PR TITLE
Fix #96: Update crushing blow and add efficiency parameter

### DIFF
--- a/dmg-calc.html
+++ b/dmg-calc.html
@@ -303,10 +303,20 @@
 					<div class="col-4">
 						<label class="form-label">CB Type</label>
 						<select id="a_cbtype" class="form-select form-select-sm" onchange="calc()">
-							<option value="0.142857">Melee (1/7)</option>
+							<option value="0.125">Melee (1/8)</option>
 							<option value="0.095238">Ranged (1/10.5)</option>
 							<option value="0.014286">Boss (1/70)</option>
 						</select>
+					</div>
+				</div>
+				<div class="row g-2 mb-1">
+					<div class="col-4">
+						<label class="form-label">+% CB Efficiency</label>
+						<div class="input-group input-group-sm">
+							<input type="number" id="a_cb_eff" class="form-control" value="0" min="0"
+							       oninput="calc()">
+							<span class="input-group-text">%</span>
+						</div>
 					</div>
 				</div>
 
@@ -576,10 +586,20 @@
 					<div class="col-4">
 						<label class="form-label">CB Type</label>
 						<select id="b_cbtype" class="form-select form-select-sm" onchange="calc()">
-							<option value="0.142857">Melee (1/7)</option>
+							<option value="0.125">Melee (1/8)</option>
 							<option value="0.095238">Ranged (1/10.5)</option>
 							<option value="0.014286">Boss (1/70)</option>
 						</select>
+					</div>
+				</div>
+				<div class="row g-2 mb-1">
+					<div class="col-4">
+						<label class="form-label">+% CB Efficiency</label>
+						<div class="input-group input-group-sm">
+							<input type="number" id="b_cb_eff" class="form-control" value="0" min="0"
+							       oninput="calc()">
+							<span class="input-group-text">%</span>
+						</div>
 					</div>
 				</div>
 
@@ -891,6 +911,7 @@
 		const cbPct    = n(p+'_cb');
 		const monHP    = n(p+'_hp', 20000);
 		const cbRatio  = parseFloat(document.getElementById(p+'_cbtype').value);
+		const cbEff    = n(p+'_cb_eff');
 		const mobRes   = n(p+'_mob_res', 33);
 		const gearRes  = n(p+'_gear_res');
 		const amp      = n(p+'_amp');
@@ -933,7 +954,7 @@
 		const finalAvg    = (finalMin + finalMax) / 2;
 
 		// 6. Crushing blow (first-hit approximation; real damage diminishes as HP drops)
-		const avgCB       = cbPct / 100 * monHP * cbRatio;
+		const avgCB       = cbPct / 100 * monHP * cbRatio * (1 + cbEff / 100);
 
 		// 7. Physical resistance
 		const effRes      = mobRes - gearRes - amp - bcry;
@@ -1061,7 +1082,7 @@
 		stats:   { inputs: ['str','str_per','dex','dex_per','off_ed','skill_ed'],  checks: [],      selects: [] },
 		auras:   { inputs: ['might','conc','fanat','how','bc','grim'],             checks: [],      selects: [] },
 		crit:    { inputs: ['ds','crit','crit_bonus','ds_bonus'],                    checks: [],      selects: [] },
-		cb:      { inputs: ['cb','hp'],                                            checks: [],      selects: ['cbtype'] },
+		cb:      { inputs: ['cb','hp','cb_eff'],                                            checks: [],      selects: ['cbtype'] },
 		physres: { inputs: ['mob_res','gear_res','amp','bcry'],                    checks: [],      selects: [] },
 		dps:     { inputs: ['fpa'],                                                checks: ['dps_on'], selects: [] },
 	};
@@ -1178,11 +1199,11 @@
 	// URL state — fixed-order array serialized as base64 JSON for compact URLs
 	// Order per panel: cat, wep, cbtype, eth, dps_on, base_min, base_max, wed,
 	//   flat_min, flat_max, str, str_per, dex, dex_per, off_ed, skill_ed,
-	//   might, conc, fanat, how, bc, grim, ds, crit, crit_bonus, ds_bonus, cb, hp,
+	//   might, conc, fanat, how, bc, grim, ds, crit, crit_bonus, ds_bonus, cb, hp, cb_eff,
 	//   mob_res, gear_res, amp, bcry, fpa
 	const URL_ORDER = ['cat','wep','cbtype','eth','dps_on','base_min','base_max','wed',
 	                   'flat_min','flat_max','str','str_per','dex','dex_per','off_ed','skill_ed',
-	                   'might','conc','fanat','how','bc','grim','ds','crit','crit_bonus','ds_bonus','cb','hp',
+	                   'might','conc','fanat','how','bc','grim','ds','crit','crit_bonus','ds_bonus','cb','hp','cb_eff',
 	                   'mob_res','gear_res','amp','bcry','fpa'];
 	const URL_CHECKS = ['eth','dps_on'];
 	const URL_SELECTS = ['cat','wep','cbtype'];


### PR DESCRIPTION
## Summary
Closes #96

- **Melee crushing blow fraction changed from 1/7 to 1/8** — updated the option value from `0.142857` to `0.125` and the dropdown label from "Melee (1/7)" to "Melee (1/8)" in both Weapon A and Weapon B panels
- **Added +% CB Efficiency parameter** — new input field in both weapon panels that applies a percentage bonus to crushing blow damage. A value of 50 means CB does 1.5x its normal damage. Integrated into the calculation as `avgCB = cbChance * monsterHP * cbRatio * (1 + cbEff / 100)`
- CB Efficiency is included in URL state persistence (`URL_ORDER`) and section copy logic (`SECTIONS.cb`)

## Changes
| What | Old | New |
|------|-----|-----|
| Melee CB fraction | 1/7 (0.142857) | 1/8 (0.125) |
| Melee CB label | "Melee (1/7)" | "Melee (1/8)" |
| CB Efficiency field | N/A | New `+% CB Efficiency` input (default 0) |

## Test plan
- [ ] Open dmg-calc.html, verify "Melee (1/8)" appears in CB Type dropdown for both panels
- [ ] Set CB Chance to 100%, Monster HP to 80000, CB Type to Melee — verify Avg CB/hit shows 10,000 (80000/8)
- [ ] Set +% CB Efficiency to 50% — verify Avg CB/hit increases to 15,000
- [ ] Copy CB section from A to B — verify CB Efficiency value copies correctly
- [ ] Save URL with CB Efficiency set, reload — verify value persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)