### PR TITLE
Fix #100: Remove leechable mobs requirement from Sanctuary Sacrifice

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1842,9 +1842,7 @@ window.soloData = {
             "type": "video"
           }
         ],
-        "notes": [
-          "Requires Leech-able Mobs"
-        ]
+        "notes": []
       },
       {
         "buildName": "Holy Freeze Sacrifice",

--- a/solo-data.json
+++ b/solo-data.json
@@ -1842,9 +1842,7 @@
             "type": "video"
           }
         ],
-        "notes": [
-          "Requires Leech-able Mobs"
-        ]
+        "notes": []
       },
       {
         "buildName": "Holy Freeze Sacrifice",


### PR DESCRIPTION
## Summary
- Removed the "Requires Leech-able Mobs" note from the Sanctuary Sacrifice Paladin build
- Updated both `solo-data.js` and `solo-data.json` — changed `"notes": ["Requires Leech-able Mobs"]` to `"notes": []`

Closes #100

## Test plan
- [ ] Verify the Sanctuary Sacrifice build no longer shows a leechable mobs requirement in the UI
- [ ] Confirm no other builds were affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)