### PR TITLE
Update #105: add Meteor starter video and sorc class build timestamps

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -48,7 +48,8 @@ window.soloData = {
           "style": "light",
           "pill": true
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s"
     },
     {
       "className": "Sorceress",
@@ -74,7 +75,8 @@ window.soloData = {
           "text": "Uber Tristram",
           "style": "dark"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=7AAuplKljvg"
     },
     {
       "className": "Druid",
@@ -579,13 +581,25 @@ window.soloData = {
       {
         "buildName": "Frozen Orb",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s",
+            "label": "Starter Guide (59:28)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {
         "buildName": "Ice Barrage",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s",
+            "label": "Starter Guide (59:28)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {
@@ -597,7 +611,13 @@ window.soloData = {
       {
         "buildName": "Combustion",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=4274s",
+            "label": "Starter Guide (1:11:14)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {
@@ -608,6 +628,11 @@ window.soloData = {
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=80&difficulty=3&quests=1&strength=60&dexterity=0&vitality=295&energy=55&coupling=1&skills=00000000000000000000000000010000000100000000010020202001002007000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CImp+Shank%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Volcanic+Diadem%2C3%2Cnone%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Volcanic+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Memory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0",
             "label": "Starter Gear",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg",
+            "label": "Starter Guide",
+            "type": "video"
           }
         ],
         "notes": []
@@ -630,6 +655,11 @@ window.soloData = {
           {
             "url": "https://www.twitch.tv/videos/2665022585",
             "label": "Phlegethon (4:20)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=5000s",
+            "label": "Starter Guide (1:23:20)",
             "type": "video"
           }
         ],

--- a/solo-data.json
+++ b/solo-data.json
@@ -48,7 +48,8 @@
           "style": "light",
           "pill": true
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s"
     },
     {
       "className": "Sorceress",
@@ -74,7 +75,8 @@
           "text": "Uber Tristram",
           "style": "dark"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=7AAuplKljvg"
     },
     {
       "className": "Druid",
@@ -579,13 +581,25 @@
       {
         "buildName": "Frozen Orb",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s",
+            "label": "Starter Guide (59:28)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {
         "buildName": "Ice Barrage",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s",
+            "label": "Starter Guide (59:28)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {
@@ -597,7 +611,13 @@
       {
         "buildName": "Combustion",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=4274s",
+            "label": "Starter Guide (1:11:14)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {
@@ -608,6 +628,11 @@
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=sorceress&level=80&difficulty=3&quests=1&strength=60&dexterity=0&vitality=295&energy=55&coupling=1&skills=00000000000000000000000000010000000100000000010020202001002007000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CDuskdeep%2CHustle+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CThe+Reaper%27s+Toll%2Cnone%2CLaying+of+Hands%2CImp+Shank%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Volcanic+Diadem%2C3%2Cnone%2C%2C%2C&armor=Skin+of+the+Vipermagi%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2Cnone&boots=Imp+Shank%2C2%2Cnone&belt=String+of+Ears%2C2%2Cnone%2C&amulet=Volcanic+Amulet+of+the+Apprentice%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=Memory+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Staff%2C3%2Cnone%2C%2C%2C%2C%2C%2C&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Fire_Mastery%2C1%2C0&effect=Defiance-mercenary%2C1%2C0",
             "label": "Starter Gear",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg",
+            "label": "Starter Guide",
+            "type": "video"
           }
         ],
         "notes": []
@@ -630,6 +655,11 @@
           {
             "url": "https://www.twitch.tv/videos/2665022585",
             "label": "Phlegethon (4:20)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=5000s",
+            "label": "Starter Guide (1:23:20)",
             "type": "video"
           }
         ],


### PR DESCRIPTION
Closes #105.

## Summary
- Adds videoUrl to the Meteor starter card (main video) and the Ice Barrage starter card (timestamp 59:28).
- Adds type: video link entries to the Sorceress class builds Frozen Orb, Ice Barrage, Combustion, Meteor, and Multishot Enchantress with timestamp-anchored URLs matching the sections in the linked guide.

Both solo-data.json and solo-data.js are kept in sync.

Timestamps applied:
- 59:28 (t=3568s) -> Ice Barrage & Frozen Orb
- 1:11:14 (t=4274s) -> Combustion
- 1:23:20 (t=5000s) -> Multishot Enchantress (Enchant Multishot Sorc)
- Meteor starter + classBuilds Meteor -> full video URL (no timestamp)

## Test plan
- [ ] Open solo.html and confirm the "Video Build Guide" pill appears on the Meteor and Ice Barrage starter cards and links to the correct URL.
- [ ] Expand the Sorceress class builds section and confirm the new "Starter Guide" video links appear on Frozen Orb, Ice Barrage, Combustion, Meteor, and Multishot Enchantress.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>