### PR TITLE
Fix #109: Rename Video links to Season 12 Video on solo.html

### DIFF
--- a/solo.html
+++ b/solo.html
@@ -834,7 +834,8 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		  } else if (link.type === 'guide') {
 			linksHtml += '<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2" href="' + link.url + '" rel="noreferrer" target="_blank">' + escapeHtml(link.label) + '</a>\n';
 		  } else if (link.type === 'video') {
-			linksHtml += '<a target="_blank" href="' + link.url + '"><span class="badge rounded-pill text-bg-success" style="font-size:0.55em;line-height:1.3">Video<br/>' + escapeHtml(link.label) + '</span></a>\n';
+			var videoPrefix = (link.label === 'Starter Guide' || link.label.indexOf('Starter Guide ') === 0 || link.label.indexOf('Build Guide') === 0) ? 'Video' : 'Season 12 Video';
+			linksHtml += '<a target="_blank" href="' + link.url + '"><span class="badge rounded-pill text-bg-success" style="font-size:0.55em;line-height:1.3">' + videoPrefix + '<br/>' + escapeHtml(link.label) + '</span></a>\n';
 		  }
 		});
 		build.notes.forEach(function(note) {


### PR DESCRIPTION
## Summary
- Renamed the "Video" badge prefix to "Season 12 Video" for Season 12 map-clear video links on solo.html
- Left Starter Guide and Build Guide video links untouched (they still render "Video") per the issue
- Build Guide badge on `build.videoUrl` (tagged builds row) is also untouched

## Implementation
In the `renderClassBuildRow` video branch, the badge prefix is now computed per link:
- Labels equal to `Starter Guide`, starting with `Starter Guide ` (with timestamp), or starting with `Build Guide` keep the `Video` prefix
- All other video-type labels render `Season 12 Video`

Result across current `solo-data.json`: 58 links become `Season 12 Video`, 12 keep `Video`.

Closes #109

## Test plan
- [ ] Open solo.html in a browser and confirm map-clear and spreadsheet video badges now read "Season 12 Video"
- [ ] Confirm Starter Guide and Build Guide video badges still read "Video"
- [ ] Confirm the Build Guide badge attached to `build.videoUrl` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)