### PR TITLE
Fix #113: Update boss.html for Season 13

### DIFF
--- a/boss.html
+++ b/boss.html
@@ -125,9 +125,9 @@
 		<td>
 			<span class="badge rounded-pill text-bg-secondary">Legend</span><br/>
 			<!--<span class="badge rounded-pill text-bg-info">Top</span><br/>-->
-			<span class="badge rounded-pill text-bg-primary">Easy</span><br/>
-			<span class="badge rounded-pill text-bg-success">Moderate</span><br/>
-			<span class="badge rounded-pill text-bg-warning">Hard</span><br/>
+			<span class="badge rounded-pill text-bg-success">Easy</span><br/>
+			<span class="badge rounded-pill text-bg-warning">Moderate</span><br/>
+			<span class="badge rounded-pill text-bg-danger">Hard</span><br/>
 			<!--<span class="badge rounded-pill text-bg-danger">Bad</span><br/>--><br/>
 		</td>
 		<td class="align-middle">
@@ -421,7 +421,7 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 			<div class="alert alert-danger" role="alert">
 				<h3>"Easy/Moderate/Hard" are relative terms when it comes to T2 boss fights.<br/>
 					You must be well-versed in the fight to even stand a chance on an Easy build.<br/>
-					Currently, this is just a copy from Season 12 (Updated: March 23rd 2026)</h3>
+					Currently, this is just a copy from Season 13 (Updated: April 18th 2026)</h3>
 			</div>
 		</td>
 	</tr>
@@ -731,31 +731,31 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		<tbody class="table-group-divider table-sorc" id="tbodySorceress3">
 		<tr>
 			<td>Meteor</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Charged Bolt</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Chain Lightning</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Hydra</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Blizzard</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -802,31 +802,31 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		<tbody class="table-group-divider table-druid" id="tbodyDruid3">
 		<tr>
 			<td>Bears</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Rabies</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Maul</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fury</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fire</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -870,31 +870,31 @@ c4 -7 6 -21 5 -30 -2 -13 3 -18 19 -18 18 0 19 -2 9 -15 -11 -14 -15 -14 -30
 
 		<tr>
 			<td>Fire Trap</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Blade Sentinel</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Light Traps</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fists of Fire</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Mind Blast</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -948,19 +948,19 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Throw</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Berserk</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Whirlwind</td>
-			<td><span class="badge rounded-pill text-bg-secondary">TBD</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1005,19 +1005,19 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Plague Jav</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Jab</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Immolation Arrow</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1064,19 +1064,19 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Desecrate</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Poison Strike</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Blood Golems</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1119,25 +1119,25 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Physical Charger</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Elemental Charger</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Holy Bolt</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Cold Charger</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1202,25 +1202,25 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		<tbody class="table-group-divider table-sorc" id="tbodySorceress">
 		<tr>
 			<td>Meteor</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Charged Bolt</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Chain Lightning</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Blizzard</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1267,31 +1267,31 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		<tbody class="table-group-divider table-druid" id="tbodyDruid">
 		<tr>
 			<td>Bears</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Rabies</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Maul</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fury</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fire</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1336,19 +1336,19 @@ c4 -7 6 -21 5 -30 -2 -13 3 -18 19 -18 18 0 19 -2 9 -15 -11 -14 -15 -14 -30
 
 		<tr>
 			<td>Blade Sentinel</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Cobra Strike</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fists of Fire</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1402,25 +1402,25 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Throw</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Berserk</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Wolf Barb</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Whirlwind</td>
-			<td><span class="badge rounded-pill text-bg-secondary">TBD</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1465,19 +1465,19 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Plague Jav</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Jab</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Cold Arrow</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1523,13 +1523,13 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Desecrate & Revive</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Poison Strike</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1572,19 +1572,19 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Physical Charger</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Cold Charger</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Smiter</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1644,19 +1644,25 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		<tbody class="table-group-divider table-sorc" id="tbodySorceress2">
 		<tr>
 			<td>Meteor</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Charged Bolt</td>
-			<td><span class="badge rounded-pill text-bg-warning">Hard</span></td>
+			<td><span class="badge rounded-pill text-bg-danger">Hard</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Blizzard</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
+			<td>
+			</td>
+		</tr>
+		<tr>
+			<td>Enchanted Exploding Arrow</td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1703,19 +1709,19 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		<tbody class="table-group-divider table-druid" id="tbodyDruid2">
 		<tr>
 			<td>Bears</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Maul</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fury</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1759,25 +1765,25 @@ c4 -7 6 -21 5 -30 -2 -13 3 -18 19 -18 18 0 19 -2 9 -15 -11 -14 -15 -14 -30
 		<tbody class="table-group-divider table-assassin" id="tbodyAssassin2">
 		<tr>
 			<td>Blade Sentinel</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Cobra Strike</td>
-			<td></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fists of Fire</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Fire kick</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1830,25 +1836,25 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		<tbody class="table-group-divider table-barbarian" id="tbodyBarbarian2">
 		<tr>
 			<td>Berserk</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Frenzy</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Wolf Barb</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
 		<tr>
 			<td>Whirlwind</td>
-			<td><span class="badge rounded-pill text-bg-secondary">TBD</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1893,7 +1899,13 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Jab</td>
-			<td><span class="badge rounded-pill text-bg-primary">Easy</span></td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
+			<td>
+			</td>
+		</tr>
+		<tr>
+			<td>Immolation Arrow</td>
+			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1939,7 +1951,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		<tr>
 			<td>Poison Strike</td>
-			<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+			<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 			<td>
 			</td>
 		</tr>
@@ -1982,13 +1994,13 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 	<tr>
 		<td>Smiter</td>
-		<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+		<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 		<td>
 		</td>
 	</tr>
 	<tr>
 		<td>Vengeance</td>
-		<td><span class="badge rounded-pill text-bg-success">Moderate</span></td>
+		<td><span class="badge rounded-pill text-bg-warning">Moderate</span></td>
 		<td>
 		</td>
 	</tr>


### PR DESCRIPTION
## Summary
Season 13 update to boss.html, covering all three change sets from #113:

1. **Tier colors remapped**: Easy -> Green, Moderate -> Yellow, Hard -> Red
2. **Boss build tiers adjusted** across dclone, rathma, and lucion (see commit message for the full list)
3. **Season label** updated from "Season 12 (Updated: March 23rd 2026)" to "Season 13 (Updated: April 18th 2026)"

Two new build entries were added (both at Easy tier for lucion):
- sorceress: Enchanted Exploding Arrow
- amazon: Immolation Arrow

Closes #113

## Test plan
- [ ] Open boss.html and confirm Easy / Moderate / Hard rows render in green / yellow / red
- [ ] Confirm each of the 11 listed boss/class/build edits appears at the intended tier
- [ ] Confirm the two new lucion entries appear under sorceress and amazon respectively
- [ ] Confirm the season label reads "Season 13 (Updated: April 18th 2026)"
- [ ] Confirm no unrelated build entries or tiers were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)