### PR TITLE
Fix #116: Add video build guide link to Barbarian War Cry starter build

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -268,7 +268,8 @@ window.soloData = {
           "style": "light",
           "pill": true
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=cNT5BRgBELY"
     },
     {
       "className": "Barbarian",

--- a/solo-data.json
+++ b/solo-data.json
@@ -268,7 +268,8 @@
           "style": "light",
           "pill": true
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=cNT5BRgBELY"
     },
     {
       "className": "Barbarian",


### PR DESCRIPTION
Closes #116

## Summary
- Adds a `videoUrl` field to the Barbarian Warcry entry in the starter builds section of `solo-data.json` (and the mirrored `solo-data.js`), pointing at the requested YouTube video: https://www.youtube.com/watch?v=cNT5BRgBELY
- `solo.html`'s `renderStarterRow` already looks for `build.videoUrl` on starter-build entries and renders a "Video Build Guide" badge next to the tags (same pattern used by the existing Barbarian Hybrid Bleed WW starter entry), so no markup/JS changes were needed.

## Test plan
- [ ] Open `solo.html` and confirm the Barbarian Warcry row in the starter builds section now shows the green "Video Build Guide" badge.
- [ ] Click the badge and confirm it opens the YouTube URL above in a new tab.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>