### PR TITLE
Fix #119: IAS calc notes for PD2 multi-hit skill changes + review

### DIFF
--- a/attackspeedcalc.html
+++ b/attackspeedcalc.html
@@ -200,7 +200,7 @@
 					<li><strong>Paladin Charge</strong> uses a sequence animation with an effective +30 WSM penalty.</li>
 					<li><strong>Shapeshift</strong> — Werewolf provides 20 base Skill IAS at slvl 1 (+1%/level after); Werebear 10 at slvl 1. Wereform uses its own FPD regardless of weapon.</li>
 					<li><strong>Trap laying</strong> uses your normal attack speed; 9fpa is the standard cap.</li>
-					<li><strong>Multi-hit skills</strong> (Zeal, Fend, Strafe, Dragon Talon, Fury, Phoenix Strike) are shown at their per-hit average frame rate; the PD2 3/5-hit cap on Zeal does not change these breakpoints.</li>
+					<li><strong>Multi-hit skills</strong> (Zeal, Fend, Strafe, Dragon Talon, Fury, Phoenix Strike) are shown at their per-hit average frame rate. PD2 hit-count tweaks (Zeal 3/5, Strafe 5, Fend 5, Dragon Talon 3, Fury 3) change total damage output but not the per-hit breakpoints.</li>
 				</ul>
 				<p class="info-text mb-0">
 					Data sourced from D2 AnimData, PD2 wiki, Amazon Basin, and Phrozen Keep.
@@ -729,7 +729,7 @@ const SKILLS = {
 		"Fend":             (wt) => ({ fpd: (wt === "Spear" || wt === "Polearm") ? 11 : (AMAZON_FPD[wt] ?? 14), group: "multi",
 		                               note: "Fend is a 5-hit sequence; FPD shown is per hit.", weaponFilter: ["Spear","Polearm"] }),
 		"Strafe":           (wt) => ({ fpd: (wt === "Bow") ? 11 : 13, group: "multi",
-		                               note: "Strafe is a 10-arrow sequence; FPD is per arrow.", weaponFilter: ["Bow","Crossbow"] }),
+		                               note: "Strafe is a 5-arrow sequence in PD2 (reduced from 10) with no next-hit delay; FPD shown is per arrow.", weaponFilter: ["Bow","Crossbow"] }),
 		"Multishot":        (wt) => ({ fpd: (wt === "Bow") ? 13 : 19, group: "standard", weaponFilter: ["Bow","Crossbow"] }),
 		"Lightning Fury":   (wt) => ({ fpd: AMAZON_FPD[wt] ?? 16, group: "standard", weaponFilter: ["Spear"] }),
 	},
@@ -791,7 +791,7 @@ const SKILLS = {
 		"Phoenix Strike":   (wt) => ({ fpd: SIN_MULTI_FPD[wt] ?? 10, group: "multi",
 		                               note: "Phoenix Strike is multi-hit; only martial-arts skill still on the multi-hit table in PD2. Per-hit FPD is faster than standard-release martial arts." }),
 		"Dragon Talon":     (_)  => ({ fpd: SIN_KICK_FPD["Dragon Talon"], group: "kick",
-		                               note: "Kick skill; kick animation independent of weapon class (WSM still applies). Reference: bubbles' Dragon Tail calc." }),
+		                               note: "Kick skill; kick animation independent of weapon class (WSM still applies). PD2: fixed 3-kick cap (base D2 was 1 + 1/6 levels). Reference: bubbles' Dragon Tail calc." }),
 		"Dragon Tail":      (_)  => ({ fpd: SIN_KICK_FPD["Dragon Tail"], group: "kick",
 		                               note: "Kick skill; kick animation independent of weapon class (WSM still applies). Reference: bubbles' Dragon Tail calc." }),
 		"Dragon Kick":      (_)  => ({ fpd: SIN_KICK_FPD["Dragon Kick"], group: "kick",
@@ -808,7 +808,7 @@ const DRUID_FORM_SKILLS = {
 	werewolf: {
 		"Attack":       () => ({ fpd: DRUID_WEREWOLF_FPD["Attack"], group: "standard" }),
 		"Fury":         () => ({ fpd: DRUID_WEREWOLF_FPD["Fury"], group: "multi",
-		                         note: "Fury is a 5-hit chain; FPD shown is per hit." }),
+		                         note: "Fury in PD2 is a fixed 3-hit chain (base D2 scaled 2-5 with levels); FPD shown is per hit." }),
 		"Feral Rage":   () => ({ fpd: DRUID_WEREWOLF_FPD["Feral Rage"], group: "standard" }),
 		"Fire Claws":   () => ({ fpd: DRUID_WEREWOLF_FPD["Fire Claws"], group: "standard" }),
 		"Rabies":       () => ({ fpd: DRUID_WEREWOLF_FPD["Rabies"], group: "standard" }),


### PR DESCRIPTION
Closes #119.

Per your note *"you need to review and determine what effects it"*, this PR is both a substantive review of the PD2 patch notes vs. the current `attackspeedcalc.html` and a small set of narrow, uncontroversial corrections. Items that require judgment are listed at the bottom for a follow-up — I didn't want to guess.

## Review passes

I WebFetched the patch notes file (`Patch.Notes.-.Project.Diablo.2.html`) three times with different prompts:

1. **Attack speed / IAS / WSM / FHR / animation / breakpoints** — every explicit mention.
2. **New skills, removed/renamed skills, animation-group or weapon-class changes** — exhaustive list.
3. **Weapon base WSM / speed / class changes, new weapon bases** — exhaustive list.

Plus a targeted pass enumerating mentions of every skill currently in the calc's `SKILLS` catalog, plus new skills (Blood Warp, Dark Pact, Gust, Desecrate, Split Throw), masteries, runewords, and wereform animation.

## Already covered by the calc

- Burst of Speed / Fanaticism / Frenzy via the Skill IAS input.
- Tiger Strike, Cobra Strike, Fists of Fire, Claws of Thunder, Blades of Ice on **standard** breakpoints (PD2 martial-arts change).
- Phoenix Strike on the multi-hit table (only MA skill still multi in PD2).
- Zeal 72%/54% caps on Phase Blade.
- Dragon Talon / Dragon Tail / Dragon Kick with kick-specific FPD.
- Werewolf / Werebear form SIAS baselines.
- Paladin Charge sequence animation with +30 WSM (formula rework tracked in #118 / #120).
- Multi-hit Jab / Fend / Strafe / Fury / Phoenix Strike with per-hit FPD shown.
- Barb Whirlwind 8-frame tick, Sin WW 8-frame tick.
- Trap-laying with SIN_TRAP_FPD.

## Changes in this PR (note-only, no math changes)

PD2 Season 1 reduced some multi-hit counts. The per-hit FPD doesn't change, so breakpoints are identical — but the descriptions were outdated. Fixed:

| Skill | Before | After |
|---|---|---|
| Strafe | \"10-arrow sequence\" | \"5-arrow sequence (reduced from 10) with no next-hit delay\" |
| Fury (Werewolf) | \"5-hit chain\" | \"fixed 3-hit chain (base D2 scaled 2-5 with levels)\" |
| Dragon Talon | (no cap mentioned) | \"fixed 3-kick cap (base D2 was 1 + 1/6 levels)\" |
| \"How it works\" footer | \"PD2 3/5-hit cap on Zeal\" | \"Zeal 3/5, Strafe 5, Fend 5, Dragon Talon 3, Fury 3 — changes total damage, not per-hit breakpoints\" |

Sanity check: these are textual only. The per-hit FPD values (Strafe 11 on Bow, Fury 11, Dragon Talon 16) are unchanged so all breakpoint tables render identically.

## Items deliberately left for follow-up (need your call)

These came up in the review but require input before implementing. Please pick the numbered items you want in a follow-up PR:

1. **Split Throw (new Barb skill, S13)** — \"throws the main hand weapon splitting it into three projectiles which return to the player.\" Unknowns: which weapon classes can cast it (throwing only, or any melee 1H)? Does it use a **throwing-weapon standard** animation or a new FPD? Any attack-speed penalty/bonus multiplier?
2. **Barb Frenzy S13 update** — splash bonuses are now local + 5 max charges at all levels. Frenzy is already in the calc as `standard`; does the max-charge change imply any animation-rate change on the charge attacks?
3. **New caster skills** (Blood Warp, Dark Pact, Curse Mastery, Gust, Desecrate) — these appear to be cast-animation / utility and shouldn't touch an attack-speed calc. Confirm and I'll leave them out, or tell me which should be added (e.g. if Blood Warp uses a weapon-based frame rate).
4. **Sorceress unique Skyfall (Vortex Orb) / Necro unique Nethercrux (Ghost Wand)** — are any of these new uniques granting oskills or SIAS that users commonly toggle in the calc? If so, which, and what IAS value?
5. **Amazon Magic Arrows S13 rework** (\"additional arrows with soft points\") — assumed to use standard Bow/Crossbow FPD like Multishot. Confirm?
6. **Multishot PD2 update** (3 arrows baseline, bonus AR, flat damage) — single release animation, so current `standard` handling should be correct. Confirm?
7. **Any oskill-granting runeword/unique with Fanaticism / Holy Freeze / Holy Shock aura** that needs named entries in the SIAS field — currently the user just types the raw number. Should we add a preset dropdown (Fanaticism +15/20/..., BoS +18/..., Holy Freeze/Shock nothing, Frenzy +14/24/...)?

## Test plan

- [x] `git diff --stat` shows only 4 lines changed, all in text notes.
- [x] Grep-verified the 4 note strings are exactly what was intended.
- [x] No JS / formula changes — existing breakpoint math is unchanged.
- [ ] Author confirms which follow-up items (1-7) to implement.