### PR TITLE
Add Amazon Summon Zon Throne of Insanity (4:50) clear

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1559,6 +1559,11 @@ window.soloData = {
             "type": "video"
           },
           {
+            "url": "https://www.youtube.com/watch?v=SaFlbj3Ouko",
+            "label": "Throne of Insanity (4:50)",
+            "type": "video"
+          },
+          {
             "url": "https://www.youtube.com/watch?v=ju4ZiyxGYP8",
             "label": "Sewers of Harrogath (3:48)",
             "type": "video"

--- a/solo-data.json
+++ b/solo-data.json
@@ -1559,6 +1559,11 @@
             "type": "video"
           },
           {
+            "url": "https://www.youtube.com/watch?v=SaFlbj3Ouko",
+            "label": "Throne of Insanity (4:50)",
+            "type": "video"
+          },
+          {
             "url": "https://www.youtube.com/watch?v=ju4ZiyxGYP8",
             "label": "Sewers of Harrogath (3:48)",
             "type": "video"


### PR DESCRIPTION
## Summary
- Adds a new map clear video submission from @EvgenyBarykin to the Amazon - Summon Zon build in `solo-data.js` and `solo-data.json`.
- Video: Throne of Insanity (4:50) — Strafe + Summon with Enigma.
- Displays automatically with the "Season 12 Video" prefix via the existing `solo.html` link-rendering logic.

Closes #122

## Test plan
- [ ] Open `solo.html`, locate the Amazon - Summon Zon row, and confirm the new "Season 12 Video / Throne of Insanity (4:50)" badge renders and links to https://www.youtube.com/watch?v=SaFlbj3Ouko
- [ ] Confirm the existing Throne of Insanity (5:13), Blood Moon (6:21), and Sewers of Harrogath (3:48) badges still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)