### PR TITLE
Add Amazon build guide video links (Pure Summon + 4 classBuilds)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -330,7 +330,8 @@ window.soloData = {
           "text": "Uber Tristram",
           "style": "dark"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=ndPULNORgXM"
     },
     {
       "className": "Amazon",
@@ -1378,6 +1379,11 @@ window.soloData = {
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=96&difficulty=3&quests=1&strength=0&dexterity=106&vitality=384&energy=0&coupling=1&skills=012001002000010000200101011000011000002000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+CBF%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Pierce%2C&amulet=Blood+Craft+-+Amazon%2C0%2C%2B+2+All+Skills%2C&ring1=Constricting+Ring%2C0%2C%2B+Life+per+kill&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Mana+per+kill&weapon=Thunderstroke%2C3%2C%2B+IAS+Crushing+Blow%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&offhand=Lidless+Wall%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor%2CLPK%2FMPK+Jewel&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B3%25+Conduit+Large+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=Shimmering+Small+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Balance",
             "label": "End-game Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=2914s",
+            "label": "Build Guide (48:34)",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1452,6 +1458,11 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=2QFkwCfCls4",
             "label": "Pandemonium Citadel (4:37)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=1966s",
+            "label": "Build Guide (32:46)",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1459,7 +1470,13 @@ window.soloData = {
       {
         "buildName": "Explosive Arrow",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=2501s",
+            "label": "Build Guide (41:41)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {
@@ -1470,6 +1487,11 @@ window.soloData = {
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=95&difficulty=3&quests=1&strength=44&dexterity=77&vitality=364&energy=0&coupling=1&skills=200000200000002000000120010100200200000100000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CGiant+Skull%2CBlack+Hades%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CAnvilguard+Strap%2CLava+Gout%2CGore+Rider%2CRazortail&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CVex+Rune%2CVex+Rune%2CVex+Rune&armor=Shaftstop%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Increased+Attack+Speed&boots=Gore+Rider%2C2%2C%2B+PDR&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Metalgrid%2C0%2C%2B+CBF%2C&ring1=Bul-Kathos%27+Death+Band%2C0%2C%2B+Damage+Reduction&ring2=Raven+Frost%2C0%2C%2B+Damage+Reduction&weapon=Stoneraven%2C3%2C%2B+Sockets+Weapon%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance",
             "label": "End-game Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=3613s",
+            "label": "Build Guide (1:00:13)",
+            "type": "video"
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -330,7 +330,8 @@
           "text": "Uber Tristram",
           "style": "dark"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=ndPULNORgXM"
     },
     {
       "className": "Amazon",
@@ -1378,6 +1379,11 @@
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=96&difficulty=3&quests=1&strength=0&dexterity=106&vitality=384&energy=0&coupling=1&skills=012001002000010000200101011000011000002000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFerocity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CInnocence+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CMarrowwalk%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Griffon%27s+Eye%2C3%2C%2B+CBF%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Life+per+kill&belt=Arachnid+Mesh%2C3%2C%2B+Pierce%2C&amulet=Blood+Craft+-+Amazon%2C0%2C%2B+2+All+Skills%2C&ring1=Constricting+Ring%2C0%2C%2B+Life+per+kill&ring2=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Mana+per+kill&weapon=Thunderstroke%2C3%2C%2B+IAS+Crushing+Blow%2C%2C%2C%2C%2CRainbow+Facet+%28Lightning%29%2CRainbow+Facet+%28Lightning%29&offhand=Lidless+Wall%2C2%2C%2B+Sockets+Off-hand%2C%2C%2C%2CScintillating+Jewel+of+Fervor%2CScintillating+Jewel+of+Fervor%2CLPK%2FMPK+Jewel&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=%2B3%25+Conduit+Large+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=%2B1+Harpoonist%27s+Grand+Charm+%2B+fhr&charm=Shimmering+Small+Charm+of+Balance&charm=%2B3%25+Conduit+Large+Charm+of+Vita&charm=%2B3%25+Conduit+Large+Charm+of+Balance",
             "label": "End-game Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=2914s",
+            "label": "Build Guide (48:34)",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1452,6 +1458,11 @@
             "url": "https://www.youtube.com/watch?v=2QFkwCfCls4",
             "label": "Pandemonium Citadel (4:37)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=1966s",
+            "label": "Build Guide (32:46)",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1459,7 +1470,13 @@
       {
         "buildName": "Explosive Arrow",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=2501s",
+            "label": "Build Guide (41:41)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {
@@ -1470,6 +1487,11 @@
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=amazon&level=95&difficulty=3&quests=1&strength=44&dexterity=77&vitality=364&energy=0&coupling=1&skills=200000200000002000000120010100200200000100000000000000000000&mercenary=Rogue+Scout+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Vigor%29%2CGiant+Skull%2CBlack+Hades%2CFaith+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Demon+Crossbow%2CAnvilguard+Strap%2CLava+Gout%2CGore+Rider%2CRazortail&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Andariel%27s+Visage%2C3%2C%2B+Sockets+Helm%2CVex+Rune%2CVex+Rune%2CVex+Rune&armor=Shaftstop%2C2%2C%2B+Sockets+Chest%2C%2C%2C%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth%2CScintillating+Jewel+of+Truth&gloves=Lancer%27s+Gloves+of+Quickness%2C1%2C%2B+Increased+Attack+Speed&boots=Gore+Rider%2C2%2C%2B+PDR&belt=Verdungo%27s+Hearty+Cord%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Metalgrid%2C0%2C%2B+CBF%2C&ring1=Bul-Kathos%27+Death+Band%2C0%2C%2B+Damage+Reduction&ring2=Raven+Frost%2C0%2C%2B+Damage+Reduction&weapon=Stoneraven%2C3%2C%2B+Sockets+Weapon%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor%2CRuby+Jewel+of+Fervor&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Vigor-mercenary%2C1%2C0&effect=Fanaticism-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=%2B1+Harpoonist%27s+Grand+Charm&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance",
             "label": "End-game Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=3613s",
+            "label": "Build Guide (1:00:13)",
+            "type": "video"
           }
         ],
         "notes": []


### PR DESCRIPTION
## Summary
- Adds `videoUrl` to the **Pure Summon (Decoy & Valk)** starter Amazon build
- Adds a timestamped **Build Guide** video link to four Amazon classBuilds, all pointing at sections of https://www.youtube.com/watch?v=ndPULNORgXM:
  - Fire Arrow → 32:46 (`&t=1966s`)
  - Explosive Arrow → 41:41 (`&t=2501s`)
  - Lightning Fury → 48:34 (`&t=2914s`)
  - Jab/Fend → 1:00:13 (`&t=3613s`)

Closes #124

## Test plan
- [ ] Open `solo.html`, locate each of the 4 class builds, and confirm a "Video / Build Guide (timestamp)" badge appears linking to the correct timestamp
- [ ] Starter builds table shows a video link icon for Pure Summon (Decoy & Valk)
- [ ] Existing links on Fire Arrow, Lightning Fury, and Jab/Fend still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)