### PR TITLE
Add Druid Wolf Fury T3 River of Blood map clear

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -794,8 +794,14 @@ window.soloData = {
       },
       {
         "buildName": "Wolf - Fury",
-        "tier": "Mid",
-        "links": [],
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://youtu.be/bYKfP5dWRS0",
+            "label": "River of Blood (6:20)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {

--- a/solo-data.json
+++ b/solo-data.json
@@ -794,8 +794,14 @@
       },
       {
         "buildName": "Wolf - Fury",
-        "tier": "Mid",
-        "links": [],
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://youtu.be/bYKfP5dWRS0",
+            "label": "River of Blood (6:20)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {


### PR DESCRIPTION
Closes #126

Adds the Druid Wolf Fury map clear submitted by @Mariusz929:
- Map: T3 River of Blood
- Clear time: 6:20
- Notes: Concept build using Ursa + high DS, takes advantage of S13 splash changes
- Video: https://youtu.be/bYKfP5dWRS0

Also bumps the Wolf - Fury tier from Mid to Decent per the submitter's assessment.

Changes applied consistently to both `solo-data.js` and `solo-data.json`.

Generated with [Claude Code](https://claude.com/claude-code)