### PR TITLE
Update starter warcry build guide link

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -269,7 +269,7 @@ window.soloData = {
           "pill": true
         }
       ],
-      "videoUrl": "https://www.youtube.com/watch?v=cNT5BRgBELY"
+      "videoUrl": "https://youtu.be/cNT5BRgBELY?si=cdULZnEk02mcPTSp&t=0"
     },
     {
       "className": "Barbarian",

--- a/solo-data.json
+++ b/solo-data.json
@@ -269,7 +269,7 @@
           "pill": true
         }
       ],
-      "videoUrl": "https://www.youtube.com/watch?v=cNT5BRgBELY"
+      "videoUrl": "https://youtu.be/cNT5BRgBELY?si=cdULZnEk02mcPTSp&t=0"
     },
     {
       "className": "Barbarian",


### PR DESCRIPTION
Closes #127

Replaces the starter warcry build guide link with the one provided in the issue:
https://youtu.be/cNT5BRgBELY?si=cdULZnEk02mcPTSp&t=0

Applied to the Barbarian Warcry entry in `starterBuilds` in both `solo-data.js` and `solo-data.json`.

Generated with [Claude Code](https://claude.com/claude-code)