### PR TITLE
Tag Druid Wolf-Fury clear as Season 13

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -799,7 +799,8 @@ window.soloData = {
           {
             "url": "https://youtu.be/bYKfP5dWRS0",
             "label": "River of Blood (6:20)",
-            "type": "video"
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -799,7 +799,8 @@
           {
             "url": "https://youtu.be/bYKfP5dWRS0",
             "label": "River of Blood (6:20)",
-            "type": "video"
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo.html
+++ b/solo.html
@@ -834,7 +834,8 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		  } else if (link.type === 'guide') {
 			linksHtml += '<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2" href="' + link.url + '" rel="noreferrer" target="_blank">' + escapeHtml(link.label) + '</a>\n';
 		  } else if (link.type === 'video') {
-			var videoPrefix = (link.label === 'Starter Guide' || link.label.indexOf('Starter Guide ') === 0 || link.label.indexOf('Build Guide') === 0) ? 'Video' : 'Season 12 Video';
+			var isGuide = (link.label === 'Starter Guide' || link.label.indexOf('Starter Guide ') === 0 || link.label.indexOf('Build Guide') === 0);
+			var videoPrefix = isGuide ? 'Video' : ('Season ' + (link.season || 12) + ' Video');
 			linksHtml += '<a target="_blank" href="' + link.url + '"><span class="badge rounded-pill text-bg-success" style="font-size:0.55em;line-height:1.3">' + videoPrefix + '<br/>' + escapeHtml(link.label) + '</span></a>\n';
 		  }
 		});


### PR DESCRIPTION
Closes #130

The Druid Wolf-Fury map clear (added in #128) was displaying as "Season 12 Video" because `solo.html` hardcoded that prefix for every video badge.

### Changes

- `solo-data.js` / `solo-data.json`: add `"season": 13` to the Wolf-Fury River of Blood link object.
- `solo.html`: the video-badge renderer now reads `link.season` and falls back to `12` when absent, so all existing Season 12 entries remain unchanged.

Minimal schema extension: only the one new entry gets the field; everything else keeps displaying as "Season 12 Video".

🤖 Generated with [Claude Code](https://claude.com/claude-code)