### PR TITLE
Fix S13 resistance overlay visibility under table-striped

### DIFF
--- a/group.html
+++ b/group.html
@@ -1716,7 +1716,7 @@ function fireConfetti() {
 					yourTimeCell = '<td class="text-center">-</td>';
 				}
 				var resCells = overlayRes
-					? '<td class="text-center fw-bold" colspan="6" style="background-color:rgba(20,20,20,0.92);color:#ffc107;letter-spacing:0.1em">TBD</td>'
+					? '<td class="text-center fw-bold" colspan="6" style="--bs-table-bg-state:rgba(20,20,20,0.92) !important;background-color:rgba(20,20,20,0.92);color:#ffc107;letter-spacing:0.1em">TBD</td>'
 					: elemCells(row[0]);
 				var topCell = isTBD ? 'TBD' : fmt(row[1]);
 				var goodCell = isTBD ? 'TBD' : fmt(row[2]);

--- a/maps.html
+++ b/maps.html
@@ -1892,7 +1892,7 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 					}
 					var slug = mapSlugs[m.name];
 					var resCells = overlayResMf
-						? '<td class="text-center fw-bold" colspan="6" style="background-color:rgba(20,20,20,0.92);color:#ffc107;letter-spacing:0.1em">TBD</td>'
+						? '<td class="text-center fw-bold" colspan="6" style="--bs-table-bg-state:rgba(20,20,20,0.92) !important;background-color:rgba(20,20,20,0.92);color:#ffc107;letter-spacing:0.1em">TBD</td>'
 						: getElemCells(m.name);
 					tr.innerHTML = '<td><a href="#map=' + slug + '&size=Medium" class="text-white">' + m.name + ' \u{1F517}</a></td>'
 						+ '<td class="text-center">' + m.top + '</td>'
@@ -1928,7 +1928,7 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 						yourCell = '<td class="text-center">-</td>';
 					}
 					var resCells = overlayResCur
-						? '<td class="text-center fw-bold" colspan="6" style="background-color:rgba(20,20,20,0.92);color:#ffc107;letter-spacing:0.1em">TBD</td>'
+						? '<td class="text-center fw-bold" colspan="6" style="--bs-table-bg-state:rgba(20,20,20,0.92) !important;background-color:rgba(20,20,20,0.92);color:#ffc107;letter-spacing:0.1em">TBD</td>'
 						: getElemCells(row[0]);
 					var topCell = isTBD ? 'TBD' : fmtMin(row[1]);
 					var goodCell = isTBD ? 'TBD' : fmtMin(row[2]);

--- a/solo.html
+++ b/solo.html
@@ -1473,7 +1473,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 					var tr = document.createElement('tr');
 					var elemCells = '';
 					if (overlayRes) {
-						elemCells = '<td class="text-center fw-bold" colspan="6" style="background-color:rgba(20,20,20,0.92);color:#ffc107;letter-spacing:0.1em">TBD</td>';
+						elemCells = '<td class="text-center fw-bold" colspan="6" style="--bs-table-bg-state:rgba(20,20,20,0.92) !important;background-color:rgba(20,20,20,0.92);color:#ffc107;letter-spacing:0.1em">TBD</td>';
 					} else {
 						for (var e = 0; e < 6; e++) {
 							var found = null;


### PR DESCRIPTION
Follow-up to #133.

The TBD overlay cells introduced in #133 were setting only `background-color`, but the three tier tables (`solo.html`, `group.html`, `maps.html`) all use `.table-striped`, which paints Bootstrap's `--bs-table-bg-state` as an **inset box-shadow** on top of the cell background on odd rows. The stripe color was completely covering the dark overlay, so on striped rows the "TBD" cell looked like a normal empty cell.

**Fix:** set `--bs-table-bg-state: rgba(20,20,20,0.92) !important` alongside the existing `background-color` on all four overlay-cell renderings:

- `solo.html` — `renderSoloTierTable` (1 cell)
- `group.html` — `render()` (1 cell)
- `maps.html` — `mf` branch (1 cell) and `exp` branch (1 cell)

Keeping `background-color` as well so the cell still works if striping is ever removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)