### PR TITLE
Solo page: rename Physical Sacrifice, tier sort, tier filter, timestamp

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "April 16th 2026",
+  "updatedDate": "April 20th 2026",
   "bannerText": "Updated with S13 Beta Testing round 1",
   "starterBuilds": [
     {
@@ -1960,8 +1960,8 @@ window.soloData = {
         "notes": []
       },
       {
-        "buildName": "2H Physical Sacrifice",
-        "tier": "Mid",
+        "buildName": "Physical Sacrifice",
+        "tier": "Top",
         "links": [
           {
             "url": "https://www.youtube.com/watch?v=d4rHxXCawSA",

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "April 16th 2026",
+  "updatedDate": "April 20th 2026",
   "bannerText": "Updated with S13 Beta Testing round 1",
   "starterBuilds": [
     {
@@ -1960,8 +1960,8 @@
         "notes": []
       },
       {
-        "buildName": "2H Physical Sacrifice",
-        "tier": "Mid",
+        "buildName": "Physical Sacrifice",
+        "tier": "Top",
         "links": [
           {
             "url": "https://www.youtube.com/watch?v=d4rHxXCawSA",

--- a/solo.html
+++ b/solo.html
@@ -683,6 +683,16 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 			<button class="btn btn-purple btn-sm fw-bold" data-bs-toggle="modal" data-bs-target="#tierModal"
 			        style="font-size:0.85em">&#9733; Map Times &amp; Details</button>
 		</div>
+		<div class="col-auto d-flex align-items-center">
+			<div class="btn-group btn-group-sm" role="group" aria-label="Build tier filter">
+				<input type="radio" class="btn-check" name="buildTierFilter" id="buildTierFilterTop" value="Top">
+				<label class="btn btn-outline-info" for="buildTierFilterTop">Top and up</label>
+				<input type="radio" class="btn-check" name="buildTierFilter" id="buildTierFilterGood" value="Good">
+				<label class="btn btn-outline-info" for="buildTierFilterGood">Good and up</label>
+				<input type="radio" class="btn-check" name="buildTierFilter" id="buildTierFilterDecent" value="Decent" checked>
+				<label class="btn btn-outline-info" for="buildTierFilterDecent">Decent and up</label>
+			</div>
+		</div>
 		<div class="col-auto d-flex align-items-center" id="bannerContainer"></div>
 	</div>
 </div>
@@ -893,6 +903,41 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 	  return fetch('solo-data.json').then(function(r) { return r.json(); });
 	}
 
+	// Tier ordering for per-class build sort + filter
+	var tierRank = { Top: 0, Good: 1, Decent: 2, Mid: 3 };
+	function tierOrd(t) { return tierRank[t] !== undefined ? tierRank[t] : 99; }
+	function getBuildTierFilterThreshold() {
+	  var checked = document.querySelector('input[name="buildTierFilter"]:checked');
+	  var val = checked ? checked.value : 'Decent';
+	  return tierOrd(val);
+	}
+
+	// Cache of per-class builds data for re-rendering on filter change
+	var cachedClassBuilds = null;
+
+	function renderClassBuildsInto(tbody, cls, builds) {
+	  var threshold = getBuildTierFilterThreshold();
+	  var sorted = builds.slice().sort(function(a, b) {
+		return tierOrd(a.tier) - tierOrd(b.tier) ||
+		  a.buildName.localeCompare(b.buildName);
+	  });
+	  tbody.innerHTML = '';
+	  sorted.forEach(function(build) {
+		if (tierOrd(build.tier) > threshold) return;
+		tbody.appendChild(renderClassBuildRow(build, cls));
+	  });
+	}
+
+	function rerenderAllClassBuilds() {
+	  if (!cachedClassBuilds) return;
+	  var classOrder = ['Sorceress', 'Druid', 'Assassin', 'Barbarian', 'Amazon', 'Necromancer', 'Paladin'];
+	  classOrder.forEach(function(cls) {
+		var tbody = document.getElementById('tbody' + cls);
+		if (!tbody) return;
+		renderClassBuildsInto(tbody, cls, cachedClassBuilds[cls] || []);
+	  });
+	}
+
 	loadData().then(function(data) {
 		// Render banner inline
 		const bannerDiv = document.getElementById('bannerContainer');
@@ -913,6 +958,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		table.appendChild(starterTbody);
 
 		// Render class sections
+		cachedClassBuilds = data.classBuilds || {};
 		const classOrder = ['Sorceress', 'Druid', 'Assassin', 'Barbarian', 'Amazon', 'Necromancer', 'Paladin'];
 		classOrder.forEach(function(cls) {
 		  table.appendChild(renderClassThead(cls));
@@ -923,10 +969,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		  tbody.className = tbodyClass;
 		  tbody.id = 'tbody' + cls;
 
-		  const builds = data.classBuilds[cls] || [];
-		  builds.forEach(function(build) {
-			tbody.appendChild(renderClassBuildRow(build, cls));
-		  });
+		  renderClassBuildsInto(tbody, cls, cachedClassBuilds[cls] || []);
 		  table.appendChild(tbody);
 		});
 
@@ -934,6 +977,11 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		setupCheckboxToggles();
 		applyFilterFromUrl();
 		filterStarterRows();
+
+		// Tier filter change -> re-render per-class builds
+		document.querySelectorAll('input[name="buildTierFilter"]').forEach(function(radio) {
+		  radio.addEventListener('change', rerenderAllClassBuilds);
+		});
 	  });
 
 	function filterStarterRows() {


### PR DESCRIPTION
Closes #137

Four changes:

1. **Renamed** `2H Physical Sacrifice` -> `Physical Sacrifice` (Sorceress) and bumped tier to `Top` in `solo-data.js` + `solo-data.json`.
2. **Sort** per-class builds by tier (`Top` -> `Good` -> `Decent` -> `Mid`) then alphabetically by name, inside the render function.
3. **Tier filter** in the top bar: radio group with `Top and up` / `Good and up` / `Decent and up`. Default `Decent and up`.
4. **Updated timestamp** refreshed to April 20th 2026.

Files touched: `solo-data.js`, `solo-data.json`, `solo.html`.

Note: `group.html` also renders `classBuilds` but was intentionally left untouched per the issue scope (`solo.html`).

Generated with Claude Code