### PR TITLE
Default build tier filter to All

### DIFF
--- a/solo.html
+++ b/solo.html
@@ -689,9 +689,9 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 				<label class="btn btn-outline-info" for="buildTierFilterTop">Top and up</label>
 				<input type="radio" class="btn-check" name="buildTierFilter" id="buildTierFilterGood" value="Good">
 				<label class="btn btn-outline-info" for="buildTierFilterGood">Good and up</label>
-				<input type="radio" class="btn-check" name="buildTierFilter" id="buildTierFilterDecent" value="Decent" checked>
+				<input type="radio" class="btn-check" name="buildTierFilter" id="buildTierFilterDecent" value="Decent">
 				<label class="btn btn-outline-info" for="buildTierFilterDecent">Decent and up</label>
-				<input type="radio" class="btn-check" name="buildTierFilter" id="buildTierFilterAll" value="All">
+				<input type="radio" class="btn-check" name="buildTierFilter" id="buildTierFilterAll" value="All" checked>
 				<label class="btn btn-outline-info" for="buildTierFilterAll">All</label>
 			</div>
 		</div>


### PR DESCRIPTION
Follow-up to #140.

Moves the `checked` attribute from the `Decent and up` radio to the `All` radio so the page loads with everything visible. Users can still narrow down with the other three options.

JS fallback in `getBuildTierFilterThreshold()` was left as `'Decent'` — it's only reached if no radio is checked (shouldn't happen in practice since one always has `checked` in markup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)