### PR TITLE
Fix #142: add Cold Arrow Amazon Build Guide video

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1442,6 +1442,11 @@ window.soloData = {
             "url": "https://youtu.be/gBZyFrOmjEE",
             "label": "Pandemonium Citadel (5:17)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=1wfkE2PEGR0",
+            "label": "Build Guide",
+            "type": "video"
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1442,6 +1442,11 @@
             "url": "https://youtu.be/gBZyFrOmjEE",
             "label": "Pandemonium Citadel (5:17)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=1wfkE2PEGR0",
+            "label": "Build Guide",
+            "type": "video"
           }
         ],
         "notes": []


### PR DESCRIPTION
Closes #142

Cold Arrow Amazon is already in the Solo tier list at Good tier. This PR adds the Build Guide YouTube link submitted in the issue (https://www.youtube.com/watch?v=1wfkE2PEGR0) as an extra `video` entry on the existing Cold Arrow build, matching the existing `{url, label, type}` schema and the bare `"Build Guide"` label convention used elsewhere (e.g. Necromancer/Barbarian entries without a specific clear-time).

Changes applied to both `solo-data.json` and the mirrored `solo-data.js`.

Source issue: submitted by @philanthropy777 via the tier-list form.