### PR TITLE
Fix #143: add Poison Blade Dance Assassin Build Guide video

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1087,6 +1087,11 @@ window.soloData = {
             "url": "https://youtu.be/paETgLGnK3o",
             "label": "Throne of Insanity (4:37)",
             "type": "video"
+          },
+          {
+            "url": "https://youtu.be/u7vm8ZcTiv4",
+            "label": "Build Guide",
+            "type": "video"
           }
         ],
         "notes": [

--- a/solo-data.json
+++ b/solo-data.json
@@ -1087,6 +1087,11 @@
             "url": "https://youtu.be/paETgLGnK3o",
             "label": "Throne of Insanity (4:37)",
             "type": "video"
+          },
+          {
+            "url": "https://youtu.be/u7vm8ZcTiv4",
+            "label": "Build Guide",
+            "type": "video"
           }
         ],
         "notes": [


### PR DESCRIPTION
Closes #143

Appended a YouTube Build Guide link (https://youtu.be/u7vm8ZcTiv4) to the existing Solo Good-tier Assassin entry "Poison Blade Dance (Chaos - Venom Dmg Focus)" in both `solo-data.json` and `solo-data.js`.

The issue title referenced "(WW)" — in PD2 parlance this is the Blade Dance variant (the Assassin's whirlwind-equivalent); the existing entry already carries a "Generic WWsin Build Guide" link, confirming it is the same build.

Source: submission by @philanthropy777 via the tier-list form.