### PR TITLE
Fix #146: Add Necro starting and build guide links

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -399,7 +399,8 @@ window.soloData = {
           "text": "Uber Tristram",
           "style": "dark"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=LKix0kGYqOE&t=1"
     },
     {
       "className": "Necromancer",
@@ -416,7 +417,8 @@ window.soloData = {
           "text": "Early Map",
           "style": "primary"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=LKix0kGYqOE&t=488s"
     },
     {
       "className": "Necromancer",
@@ -1713,6 +1715,11 @@ window.soloData = {
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=92&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=200101010120010101002000010100000000000001000001000000010001200010&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CImp+Shank%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Harlequin+Crest%2C3%2C%2B+Skill%2C%2CUm+Rune%2CUm+Rune&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Gravepalm%2C2%2C%2B+Faster+Cast+Rate&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+Faster+Cast+Rate%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Grim%27s+Burning+Dead%2C2%2C%2B+All+Skills%2C%2C%2CIst+Rune%2CIst+Rune%2CIst+Rune%2CScintillating+Jewel+of+Freedom&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=Amber+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita",
             "label": "End-game Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=LKix0kGYqOE&t=2018s",
+            "label": "Build Guide (33:38)",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1725,6 +1732,11 @@ window.soloData = {
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000202000200120200000000000000000000001000001000000010000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CGore+Rider%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Golemlord%27s+Diadem+of+the+Magus%2C3%2C%2B+Skill%2C%2C%2C&armor=Trang-Oul%27s+Scales%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Golemlord%27s+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Golemlord%27s+Tomb+Wand+of+the+Archmage%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=Golemlord%27s+Minion+Skull+of+the+Archmage%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life",
             "label": "Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=LKix0kGYqOE&t=2791s",
+            "label": "Build Guide (46:31)",
+            "type": "video"
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -399,7 +399,8 @@
           "text": "Uber Tristram",
           "style": "dark"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=LKix0kGYqOE&t=1"
     },
     {
       "className": "Necromancer",
@@ -416,7 +417,8 @@
           "text": "Early Map",
           "style": "primary"
         }
-      ]
+      ],
+      "videoUrl": "https://www.youtube.com/watch?v=LKix0kGYqOE&t=488s"
     },
     {
       "className": "Necromancer",
@@ -1713,6 +1715,11 @@
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=92&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=200101010120010101002000010100000000000001000001000000010001200010&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CImp+Shank%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Harlequin+Crest%2C3%2C%2B+Skill%2C%2CUm+Rune%2CUm+Rune&armor=Enigma+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Gravepalm%2C2%2C%2B+Faster+Cast+Rate&boots=Marrowwalk%2C3%2Cnone&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Blood+Craft+-+Necromancer%2C0%2C%2B+Faster+Cast+Rate%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Grim%27s+Burning+Dead%2C2%2C%2B+All+Skills%2C%2C%2CIst+Rune%2CIst+Rune%2CIst+Rune%2CScintillating+Jewel+of+Freedom&offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=Amber+Small+Charm+of+Vita&charm=Emerald+Small+Charm+of+Vita&charm=Sapphire+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Vita",
             "label": "End-game Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=LKix0kGYqOE&t=2018s",
+            "label": "Build Guide (33:38)",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1725,6 +1732,11 @@
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=94&difficulty=3&quests=1&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&skills=000000202000200120200000000000000000000001000001000000010000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CFlickering+Flame+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Visage%2CShaftstop%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CDracul%27s+Grasp%2CGore+Rider%2CString+of+Ears&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Golemlord%27s+Diadem+of+the+Magus%2C3%2C%2B+Skill%2C%2C%2C&armor=Trang-Oul%27s+Scales%2C2%2C%2B+Skill%2C%2C%2C%2C%2C%2C&gloves=Magefist%2C1%2C%2B+Faster+Cast+Rate&boots=Imp+Shank%2C2%2C%2B+Faster+Run+Walk&belt=Arachnid+Mesh%2C3%2C%2B+Faster+Cast+Rate%2C&amulet=Golemlord%27s+Amulet+of+the+Apprentice%2C0%2C%2B+2+All+Skills%2C&ring1=Bul+Katho%27s+Wedding+Band%2C0%2C%2B+Faster+Cast+Rate&ring2=The+Stone+of+Jordan%2C0%2C%2B+Faster+Cast+Rate&weapon=Golemlord%27s+Tomb+Wand+of+the+Archmage%2C2%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&offhand=Golemlord%27s+Minion+Skull+of+the+Archmage%2C3%2C%2B+All+Skills%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Resist_Fire-mercenary_helm%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus+%2B2&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+frw&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+fhr&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life&charm=%2B1+Graverobber%27s+Grand+Charm+%2B+life",
             "label": "Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=LKix0kGYqOE&t=2791s",
+            "label": "Build Guide (46:31)",
+            "type": "video"
           }
         ],
         "notes": []


### PR DESCRIPTION
Closes #146

## Summary
Adds user-submitted YouTube guide links to the Necromancer entries on the Solo page:

**Starter builds** (added `videoUrl`):
- Clay Golems (00:00): https://www.youtube.com/watch?v=LKix0kGYqOE&t=1
- Teeth / Bonespear (08:08): https://www.youtube.com/watch?v=LKix0kGYqOE&t=488s

**End-game builds** (added "Build Guide" video link alongside existing planners):
- Elemental Summoner (Mage Skeles + Ele Revives) — Build Guide (33:38)
- Fire Golems — Build Guide (46:31)

Applied to both `solo-data.json` and the mirrored `solo-data.js`.

## Test plan
- [ ] Open solo.html, verify the Necromancer starter rows for Clay Golems and Teeth / Bonespear show the Video Build Guide badge linking to the correct timestamp
- [ ] In the Necromancer endgame section, verify Elemental Summoner and Fire Golems each show a Build Guide (MM:SS) video link pointing to the correct timestamp