### PR TITLE
Fix #147: Remove dead warcry barb season 12 sewers link

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1182,11 +1182,6 @@ window.soloData = {
         "tier": "Top",
         "links": [
           {
-            "url": "https://streamable.com/cq8k8s",
-            "label": "Sewers of Harrogath (3:00)",
-            "type": "video"
-          },
-          {
             "url": "https://www.youtube.com/watch?v=cNT5BRgBELY&t=4949s",
             "label": "Build Guide (1:22:29)",
             "type": "video"

--- a/solo-data.json
+++ b/solo-data.json
@@ -1182,11 +1182,6 @@
         "tier": "Top",
         "links": [
           {
-            "url": "https://streamable.com/cq8k8s",
-            "label": "Sewers of Harrogath (3:00)",
-            "type": "video"
-          },
-          {
             "url": "https://www.youtube.com/watch?v=cNT5BRgBELY&t=4949s",
             "label": "Build Guide (1:22:29)",
             "type": "video"


### PR DESCRIPTION
Closes #147

## Summary
- Removes the dead `https://streamable.com/cq8k8s` link ("Sewers of Harrogath (3:00)") from the Warcry Barbarian entry in `solo-data.json` and `solo-data.js`.
- The link returns HTTP 400 Bad Request — this was a season 12 sewers clear that is no longer available.
- Other links on the build (Build Guide video) are preserved.

## Test plan
- [ ] Open `solo.html`, navigate to Barbarian > Warcry (Top tier) and confirm only the Build Guide link remains.
- [ ] JSON files validated: both `solo-data.json` and the JSON body of `solo-data.js` parse cleanly.