### PR TITLE
Fix #148: Add Dragon Tail and WW 2H (Uldyssian) build guide links

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -970,6 +970,11 @@ window.soloData = {
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=91&difficulty=3&quests=1&strength=140&dexterity=130&vitality=195&energy=0&coupling=1&skills=0020000100002000200101200001010001000002000001000001000000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CMarrowwalk%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Fortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+Deadly+Strike&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+x+Enhanced+Damage%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&ring2=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&weapon=Astreon%27s+Iron+Ward%2C3%2C%2B+Sockets+Weapon%2C%2C%2CLo+Rune%2CLo+Rune%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Phoenix+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Monarch%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Redemption-offhand%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance",
             "label": "End-game Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=Sz62cayCAuE",
+            "label": "Build Guide",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1235,6 +1240,11 @@ window.soloData = {
           {
             "url": "https://www.youtube.com/watch?v=cNT5BRgBELY&t=2154s",
             "label": "Build Guide (35:54)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=Sz62cayCAuE",
+            "label": "Build Guide (Uldyssian)",
             "type": "video"
           }
         ],

--- a/solo-data.json
+++ b/solo-data.json
@@ -970,6 +970,11 @@
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=assassin&level=91&difficulty=3&quests=1&strength=140&dexterity=130&vitality=195&energy=0&coupling=1&skills=0020000100002000200101200001010001000002000001000001000000010000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CCrown+of+Ages%2CTemplar%27s+Might%2CInfinity+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2CBloodfist%2CMarrowwalk%2CSiggard%27s+Staunch&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Veil+of+Steel%2C3%2C%2B+Sockets+Helm%2C%2C%2C&armor=Fortitude+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Archon+Plate%2C3%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Hellmouth%2C2%2C%2B+Deadly+Strike&boots=Gore+Rider%2C2%2C%2B+Faster+Run+Walk&belt=Siggard%27s+Staunch%2C3%2C%2B+Increased+Attack+Speed%2C&amulet=Highlord%27s+Wrath%2C0%2C%2B+2+x+Enhanced+Damage%2C&ring1=Wisp+Projector%2C0%2C%2B+Faster+Run%2FWalk&ring2=Raven+Frost%2C0%2C%2B+Faster+Run%2FWalk&weapon=Astreon%27s+Iron+Ward%2C3%2C%2B+Sockets+Weapon%2C%2C%2CLo+Rune%2CLo+Rune%2CRainbow+Facet+%28Fire%29%2CRainbow+Facet+%28Fire%29&offhand=Phoenix+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Monarch%2C3%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Redemption-offhand%2C1%2C0&effect=Defiance-mercenary%2C1%2C0&effect=Might-mercenary_armor%2C1%2C0&effect=Conviction-mercenary_weapon%2C1%2C0&charm=Hellfire+Torch&charm=Annihilus&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Sharp+Grand+Charm+of+Vita&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance&charm=Shimmering+Small+Charm+of+Balance",
             "label": "End-game Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=Sz62cayCAuE",
+            "label": "Build Guide",
+            "type": "video"
           }
         ],
         "notes": []
@@ -1235,6 +1240,11 @@
           {
             "url": "https://www.youtube.com/watch?v=cNT5BRgBELY&t=2154s",
             "label": "Build Guide (35:54)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=Sz62cayCAuE",
+            "label": "Build Guide (Uldyssian)",
             "type": "video"
           }
         ],


### PR DESCRIPTION
Closes #148

## Summary
Adds user-submitted YouTube build guide links on the Solo page:

- **Assassin — Dragon Tail (Fire Kick) Astreons + Phoenix RW**: added `Build Guide` video link to https://www.youtube.com/watch?v=Sz62cayCAuE
- **Barbarian — Whirlwind (2-H)**: added a second `Build Guide (Uldyssian)` video link to https://www.youtube.com/watch?v=Sz62cayCAuE (alongside the existing `Build Guide (35:54)` video)

Applied to both `solo-data.json` and the mirrored `solo-data.js`.

## Note to reviewer
The issue body listed the **same URL** (`Sz62cayCAuE`) for both the Dragon Tail and Whirlwind items. The URL was used as given for both entries per the issue instructions, but this looks like a possible copy/paste slip in the original report. If a different video was intended for Dragon Tail, please update the link in a follow-up.

Also: this is the first time a "creator tag" (Uldyssian) is being used in a label in `solo-data.json`. It was rendered as `"Build Guide (Uldyssian)"` — no prior convention existed, so feel free to tweak if you'd prefer a different format (e.g. `"Uldyssian Build Guide"`).

## Test plan
- [ ] Open solo.html, Assassin section: verify `Dragon Tail (Fire Kick) Astreons + Phoenix RW` shows a new `Build Guide` video badge linking to https://www.youtube.com/watch?v=Sz62cayCAuE
- [ ] Barbarian section: verify `Whirlwind (2-H)` shows both the existing `Build Guide (35:54)` video and a new `Build Guide (Uldyssian)` video link