### PR TITLE
Fix #154: Retier Split Throw (Barb) to Decent; add Sewers 4:20 clear video

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1354,8 +1354,14 @@ window.soloData = {
       },
       {
         "buildName": "Split Throw",
-        "tier": "Bad",
-        "links": [],
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://youtu.be/ZV-RYzBWgFA?si=rqb1JExc54Cncxko&t=1298",
+            "label": "Sewers of Harrogath (4:20)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {

--- a/solo-data.json
+++ b/solo-data.json
@@ -1354,8 +1354,14 @@
       },
       {
         "buildName": "Split Throw",
-        "tier": "Bad",
-        "links": [],
+        "tier": "Decent",
+        "links": [
+          {
+            "url": "https://youtu.be/ZV-RYzBWgFA?si=rqb1JExc54Cncxko&t=1298",
+            "label": "Sewers of Harrogath (4:20)",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {


### PR DESCRIPTION
Closes #154

## Summary
- Retier Solo Barbarian **Split Throw** from `Bad` to `Decent`.
- Add Sewers of Harrogath 4:20 clear video as supporting evidence (timestamped link into the video).

## Changes
- `solo-data.json`: `buildsByClass.Barbarian` -> `Split Throw` -> `tier: "Decent"`; added video link.
- `solo-data.js`: mirrored identically.

## Notes
Per the issue, the "Build Planner Link" field on the template actually contained a YouTube clear video (Sewers 4:20). Encoded as a `{type: "video"}` link following the existing convention used elsewhere in the file (e.g. "Sewers of Harrogath (3:34)").

## Test plan
- [x] `solo-data.json` parses as JSON
- [x] `solo-data.js` body (after stripping `window.soloData = ` prefix) parses as JSON
- [x] `solo-data.json` and `solo-data.js` are structurally identical

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>