### PR TITLE
Fix #157: shorten Updated timestamp and document in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+Instructions for Claude / future contributors when editing this repo.
+
+## Updated timestamp
+
+Whenever `solo.html`, `boss.html` (bossing), or `group.html` (or their backing data files `solo-data.json`/`solo-data.js`, `group-data.json`/`group-data.js`) is edited, refresh the "Updated" timestamp on that page to the current edit date.
+
+- Use the shortened format: `Updated — <Month> <Dth> <YYYY>` (e.g. `Updated — April 20th 2026`).
+- Ordinal suffix rules: `1st`, `2nd`, `3rd`, `21st`, `22nd`, `23rd`, `31st`; everything else is `th`.
+- For `solo.html` and `group.html`, update the `updatedDate` field (and keep `bannerText` as `"Updated"`) in both the `.json` and `.js` data files so the banner stays in sync.
+- For `boss.html`, update the inline `Updated — <date>` text near the top of the bosses table.

--- a/boss.html
+++ b/boss.html
@@ -421,7 +421,7 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 			<div class="alert alert-danger" role="alert">
 				<h3>"Easy/Moderate/Hard" are relative terms when it comes to T2 boss fights.<br/>
 					You must be well-versed in the fight to even stand a chance on an Easy build.<br/>
-					Season 13 (Updated: April 18th 2026)</h3>
+					Season 13 &mdash; Updated &mdash; April 22nd 2026</h3>
 			</div>
 		</td>
 	</tr>

--- a/group-data.js
+++ b/group-data.js
@@ -1,7 +1,7 @@
 window.groupData = {
   "season": 13,
-  "updatedDate": "April 17th 2026",
-  "bannerText": "Updated with S13 Beta Testing round 1",
+  "updatedDate": "April 22nd 2026",
+  "bannerText": "Updated",
   "generalists": {
     "title": "Public Map Focused P8 Mapping",
     "descriptions": [

--- a/group-data.json
+++ b/group-data.json
@@ -1,7 +1,7 @@
 {
   "season": 13,
-  "updatedDate": "April 17th 2026",
-  "bannerText": "Updated with S13 Beta Testing round 1",
+  "updatedDate": "April 22nd 2026",
+  "bannerText": "Updated",
   "generalists": {
     "title": "Public Map Focused P8 Mapping",
     "descriptions": [

--- a/solo-data.js
+++ b/solo-data.js
@@ -1,7 +1,7 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "April 20th 2026",
-  "bannerText": "Updated with S13 Beta Testing round 1",
+  "updatedDate": "April 22nd 2026",
+  "bannerText": "Updated",
   "starterBuilds": [
     {
       "className": "Sorceress",

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,7 +1,7 @@
 {
   "season": 13,
-  "updatedDate": "April 20th 2026",
-  "bannerText": "Updated with S13 Beta Testing round 1",
+  "updatedDate": "April 22nd 2026",
+  "bannerText": "Updated",
   "starterBuilds": [
     {
       "className": "Sorceress",


### PR DESCRIPTION
## Summary
- Shortened the "Updated" banner on `solo.html` and `group.html` by setting `bannerText` to `"Updated"` and refreshed `updatedDate` to `April 22nd 2026` in both the `.json` and `.js` data files. Rendered banner now reads `Updated — April 22nd 2026`.
- Normalized the inline timestamp on `boss.html` (the "bossing" page — there is no `bossing.html` in the repo) to `Season 13 — Updated — April 22nd 2026` using em dashes.
- Added a new `CLAUDE.md` with a concise rule: whenever `solo.html`, `boss.html`, or `group.html` is edited, refresh the `Updated — <Month> <Dth> <YYYY>` timestamp, with ordinal-suffix guidance.

Closes #157