### PR TITLE
Fix #156: retier Holy Fire Sacrifice (Paladin) to Top with video link

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -2036,7 +2036,7 @@ window.soloData = {
       },
       {
         "buildName": "Holy Fire Sacrifice",
-        "tier": "Good",
+        "tier": "Top",
         "links": [
           {
             "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=1648s",
@@ -2053,6 +2053,11 @@ window.soloData = {
             "label": "Armory - Pandemonium Citadel (4:18)",
             "type": "armory",
             "mapLabel": "Pandemonium Citadel (4:18)"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=8lF16MzGYtU",
+            "label": "River of Blood (3:57)",
+            "type": "video"
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -2036,7 +2036,7 @@
       },
       {
         "buildName": "Holy Fire Sacrifice",
-        "tier": "Good",
+        "tier": "Top",
         "links": [
           {
             "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=1648s",
@@ -2053,6 +2053,11 @@
             "label": "Armory - Pandemonium Citadel (4:18)",
             "type": "armory",
             "mapLabel": "Pandemonium Citadel (4:18)"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=8lF16MzGYtU",
+            "label": "River of Blood (3:57)",
+            "type": "video"
           }
         ],
         "notes": []


### PR DESCRIPTION
## Summary

- Retiered the Paladin build "Holy Fire Sacrifice" in the Solo list from `Good` to `Top`, as requested in the issue.
- Added a new video link entry to that build's `links` array for the submitted Season 13 clear: `River of Blood (3:57)` (https://www.youtube.com/watch?v=8lF16MzGYtU). Label follows the existing `<Map> (M:SS)` convention used across the file; video title is "S13 OBT non-ladder Fire sac after nerfs test 3:57 river".
- `solo-data.json` and `solo-data.js` updated identically so the two stay in sync.
- `updatedDate` already reads `April 22nd 2026` (today), so no timestamp change was needed per CLAUDE.md.

Closes #156