### PR TITLE
Fix #159: add Blades of Ice (Assassin) Skovos 3:20 clear video

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1130,6 +1130,11 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=y9JqNm-j1SI",
             "label": "Skovos Stronghold (3:38)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=E1IAw6nqTRU",
+            "label": "Skovos Stronghold (3:20)",
+            "type": "video"
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1130,6 +1130,11 @@
             "url": "https://www.youtube.com/watch?v=y9JqNm-j1SI",
             "label": "Skovos Stronghold (3:38)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=E1IAw6nqTRU",
+            "label": "Skovos Stronghold (3:20)",
+            "type": "video"
           }
         ],
         "notes": []


### PR DESCRIPTION
## Summary
- Adds the Skovos Stronghold (3:20) map clear video submitted in issue #159 to the Blades of Ice (Assassin) entry in both `solo-data.json` and `solo-data.js`.
- Follows the existing `{ url, label, type: "video" }` convention used elsewhere (e.g. Holy Fire Sacrifice's Pandemonium Citadel clear).
- Label uses the canonical map name "Skovos Stronghold" to match other Skovos clear labels already in the file. The submitter's "Fortified / 157% density" note was dropped — no existing entry encodes density/map-modifier info, so no convention to follow.
- `updatedDate` is already `April 22nd 2026`, so the timestamp was left untouched.

## Test plan
- [x] `python -c "import json; json.load(open('solo-data.json'))"` passes
- [x] `solo-data.json` and `solo-data.js` remain byte-identical past line 1 (`diff <(tail -n +2 solo-data.json) <(tail -n +2 solo-data.js)` is empty)
- [x] Diff is minimal: one 5-line addition to each file, no other changes

Closes #159