### PR TITLE
Fix #160: add Blades of Ice (Assassin) Ancestral Trial 4:00 clear video

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1135,6 +1135,11 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=E1IAw6nqTRU",
             "label": "Skovos Stronghold (3:20)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=aV1Sa5iuWNY",
+            "label": "Ancestral Trial (4:00)",
+            "type": "video"
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1135,6 +1135,11 @@
             "url": "https://www.youtube.com/watch?v=E1IAw6nqTRU",
             "label": "Skovos Stronghold (3:20)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=aV1Sa5iuWNY",
+            "label": "Ancestral Trial (4:00)",
+            "type": "video"
           }
         ],
         "notes": []


### PR DESCRIPTION
## Summary
- Adds an Ancestral Trial (4:00) clear video submitted in issue #160 to the Blades of Ice Assassin entry in `solo-data.json` and mirrors the change to `solo-data.js`.
- Label matches the existing repo convention `Ancestral Trial (M:SS)` (cf. lines 756, 950, 1904 in solo-data.json).
- Appended immediately after the Skovos 3:20 entry added in #165.

## Notes
- Submission metadata `Fortified / 127% density` is dropped — the data file has no encoding convention for map mods (consistent with how #159 was handled). Maintainer can decide later whether to introduce a convention for this.
- Did NOT touch the pre-existing duplicate Skovos 3:38 entries flagged on #165 — out of scope for this issue.
- `updatedDate` already `April 22nd 2026`; no change needed.

## Test plan
- [x] `python -m json.tool solo-data.json` parses cleanly
- [x] `diff <(tail -n +2 solo-data.json) <(tail -n +2 solo-data.js)` — byte-identical past line 1
- [x] Diff is exactly 2 files, +5 lines each (10 total insertions, 0 deletions)

Closes #160

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>