### PR TITLE
Fix #168: remove Leap Attack from Barbarian starter builds

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -217,23 +217,6 @@ window.soloData = {
     },
     {
       "className": "Barbarian",
-      "buildName": "Leap Attack",
-      "plannerUrl": null,
-      "plannerLabel": null,
-      "tags": [
-        {
-          "text": "Chaos",
-          "style": "danger",
-          "pill": true
-        },
-        {
-          "text": "Early Map",
-          "style": "primary"
-        }
-      ]
-    },
-    {
-      "className": "Barbarian",
       "buildName": "Big Shouts + Find Item (A2 Offensive Merc)",
       "plannerUrl": null,
       "plannerLabel": null,

--- a/solo-data.json
+++ b/solo-data.json
@@ -217,23 +217,6 @@
     },
     {
       "className": "Barbarian",
-      "buildName": "Leap Attack",
-      "plannerUrl": null,
-      "plannerLabel": null,
-      "tags": [
-        {
-          "text": "Chaos",
-          "style": "danger",
-          "pill": true
-        },
-        {
-          "text": "Early Map",
-          "style": "primary"
-        }
-      ]
-    },
-    {
-      "className": "Barbarian",
       "buildName": "Big Shouts + Find Item (A2 Offensive Merc)",
       "plannerUrl": null,
       "plannerLabel": null,


### PR DESCRIPTION
## Summary
- Removes the `Barbarian Leap Attack` entry from the `starterBuilds` array in both `solo-data.json` and `solo-data.js`.
- Mirrors the removal in both files so they remain byte-identical past line 1.
- No other `Leap Attack` references (in class builds) were touched.

## Changes
- 17 lines deleted in `solo-data.json` (starterBuilds entry for Barbarian Leap Attack)
- 17 lines deleted in `solo-data.js` (same entry mirrored)

## Validation
- `python -c "import json; json.load(open('solo-data.json'))"` passes
- `diff <(tail -n +2 solo-data.js) <(tail -n +2 solo-data.json)` is empty (file parity OK)

## Test plan
- [ ] Verify `solo.html` starter list no longer shows Barbarian Leap Attack
- [ ] Verify other Barbarian starter entries (e.g. Big Shouts + Find Item) still render
- [ ] Verify `Leap Attack (Physical)` and `Leap Attack (Ele Proc)` still appear in the Barbarian class builds section

Closes #168