### PR TITLE
Add Assassin Blades of Ice Throne of Insanity clear (3:45)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "April 22nd 2026",
+  "updatedDate": "April 23rd 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1122,6 +1122,11 @@ window.soloData = {
           {
             "url": "https://www.youtube.com/watch?v=aV1Sa5iuWNY",
             "label": "Ancestral Trial (4:00)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=aIcjPSvKcsM",
+            "label": "Throne of Insanity (3:45)",
             "type": "video"
           }
         ],

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "April 22nd 2026",
+  "updatedDate": "April 23rd 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1122,6 +1122,11 @@
           {
             "url": "https://www.youtube.com/watch?v=aV1Sa5iuWNY",
             "label": "Ancestral Trial (4:00)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=aIcjPSvKcsM",
+            "label": "Throne of Insanity (3:45)",
             "type": "video"
           }
         ],


### PR DESCRIPTION
## Summary
- Adds a new video link to the Assassin "Blades of Ice" build in `solo-data.json` / `solo-data.js`: Throne of Insanity (3:45) submitted by Homelab123.
- Bumps `updatedDate` to `April 23rd 2026` per CLAUDE.md.

Video: https://www.youtube.com/watch?v=aIcjPSvKcsM

Note: the existing schema only has `url`, `label`, `type` per link (and a per-build `notes` array). I did not invent fields for submitter attribution, Fortified, or 165% density since nothing comparable exists in current entries. If you want those surfaced, let me know the preferred shape and I'll follow up.

Closes #170

## Test plan
- [ ] solo.html renders the new Throne of Insanity (3:45) link under Assassin > Blades of Ice
- [ ] Banner on solo.html shows `Updated - April 23rd 2026`