### PR TITLE
Add Amazon Magic Arrow Pande T3 173% +1 clears (5:00)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "April 22nd 2026",
+  "updatedDate": "April 23rd 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1561,7 +1561,18 @@ window.soloData = {
       {
         "buildName": "Magic Arrow",
         "tier": "Mid",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=Hh7OFwFSSUA&t",
+            "label": "Pande T3 173% +1 - 5min clear (V2)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=1AHfb-NHghY",
+            "label": "Pande T3 173% +1 - 5min clear",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {

--- a/solo-data.js
+++ b/solo-data.js
@@ -1565,12 +1565,14 @@ window.soloData = {
           {
             "url": "https://www.youtube.com/watch?v=Hh7OFwFSSUA&t",
             "label": "Pande T3 173% +1 - 5min clear (V2)",
-            "type": "video"
+            "type": "video",
+            "season": 13
           },
           {
             "url": "https://www.youtube.com/watch?v=1AHfb-NHghY",
             "label": "Pande T3 173% +1 - 5min clear",
-            "type": "video"
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "April 22nd 2026",
+  "updatedDate": "April 23rd 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1561,7 +1561,18 @@
       {
         "buildName": "Magic Arrow",
         "tier": "Mid",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=Hh7OFwFSSUA&t",
+            "label": "Pande T3 173% +1 - 5min clear (V2)",
+            "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=1AHfb-NHghY",
+            "label": "Pande T3 173% +1 - 5min clear",
+            "type": "video"
+          }
+        ],
         "notes": []
       },
       {

--- a/solo-data.json
+++ b/solo-data.json
@@ -1565,12 +1565,14 @@
           {
             "url": "https://www.youtube.com/watch?v=Hh7OFwFSSUA&t",
             "label": "Pande T3 173% +1 - 5min clear (V2)",
-            "type": "video"
+            "type": "video",
+            "season": 13
           },
           {
             "url": "https://www.youtube.com/watch?v=1AHfb-NHghY",
             "label": "Pande T3 173% +1 - 5min clear",
-            "type": "video"
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []


### PR DESCRIPTION
## Summary
- Populates the previously-empty `links` array on Amazon > Magic Arrow in `solo-data.json` / `solo-data.js` with two video submissions from soleilsamuel-ops: Pande T3 173% +1 area level, 5 minute clears.
- Bumps `updatedDate` to `April 23rd 2026` per CLAUDE.md.

Videos:
- https://www.youtube.com/watch?v=Hh7OFwFSSUA&t
- https://www.youtube.com/watch?v=1AHfb-NHghY

Note: the submitter describes both videos as the same Pande T3 173% +1 clear with variant setups (Asylum / Brand). YouTube titles don't distinguish them, so I labeled the first `(V2)` (matching its title suffix) and the second as the base label. Happy to relabel if you know which is Asylum vs Brand.

The submitter's Google Doc guide link was intentionally omitted per their explicit request ("please don't share that").

Closes #171

## Test plan
- [ ] solo.html renders the two new video links under Amazon > Magic Arrow
- [ ] Banner on solo.html shows `Updated - April 23rd 2026`