### PR TITLE
Update Season 13 Solo/MF map clear times

### DIFF
--- a/maps.html
+++ b/maps.html
@@ -1706,35 +1706,35 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 	// ===== Season 13 (current) =====
 	var mfDataS13 = [
 		{ tier: 3, maps: [
-			{ name: 'Kehjistan Marketplace', top: '4:18', good: '6:28', decent: '8:37', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-			{ name: 'Bastion Keep', top: '4:03', good: '6:05', decent: '8:07', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Arreat Battlefield', top: '4:02', good: '6:03', decent: '8:04', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
-			{ name: 'River of Blood', top: '3:58', good: '5:56', decent: '7:55', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Demon Road', top: '3:49', good: '5:43', decent: '7:37', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
-			{ name: 'Royal Crypts', top: '3:48', good: '5:43', decent: '7:37', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-			{ name: 'Blood Moon', top: '5:17', good: '7:56', decent: '10:35', elems: [] },
-			{ name: 'Skovos Stronghold', top: '3:17', good: '4:55', decent: '6:34', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] }
+			{ name: 'Kehjistan Marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+			{ name: 'Bastion Keep', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+			{ name: 'Arreat Battlefield', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
+			{ name: 'River of Blood', top: '4:00', good: '5:55', decent: '7:55', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+			{ name: 'Demon Road', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
+			{ name: 'Royal Crypts', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+			{ name: 'Blood Moon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
+			{ name: 'Skovos Stronghold', top: '3:15', good: '4:55', decent: '6:35', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] }
 		]},
 		{ tier: 2, maps: [
-			{ name: 'Canyon of Sescheron', top: '4:52', good: '7:18', decent: '9:44', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
-			{ name: 'Halls of Torture', top: '4:03', good: '6:04', decent: '8:06', elems: [] },
-			{ name: "Horazon's Memory", top: '3:52', good: '5:49', decent: '7:45', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Ashen Plains', top: '3:48', good: '5:42', decent: '7:35', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Throne of Insanity', top: '3:24', good: '5:06', decent: '6:48', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Sewers of Harrogath', top: '3:06', good: '4:39', decent: '6:12', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
-			{ name: 'Sanatorium', top: '2:56', good: '4:25', decent: '5:53', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Ruined Cistern', top: '2:40', good: '4:01', decent: '5:20', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
-			{ name: 'Pandemonium Citadel', top: '2:31', good: '3:47', decent: '5:02', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
+			{ name: 'Canyon of Sescheron', top: '4:50', good: '7:20', decent: '9:45', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
+			{ name: 'Halls of Torture', top: '4:05', good: '6:05', decent: '8:05', elems: [] },
+			{ name: "Horazon's Memory", top: '3:50', good: '5:50', decent: '7:45', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+			{ name: 'Ashen Plains', top: '3:50', good: '5:40', decent: '7:35', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+			{ name: 'Throne of Insanity', top: '3:25', good: '5:05', decent: '6:50', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+			{ name: 'Sewers of Harrogath', top: '3:05', good: '4:40', decent: '6:10', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
+			{ name: 'Sanatorium', top: '2:55', good: '4:25', decent: '5:55', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
+			{ name: 'Ruined Cistern', top: '2:40', good: '4:00', decent: '5:20', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
+			{ name: 'Pandemonium Citadel', top: '2:30', good: '3:45', decent: '5:00', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
 		]},
 		{ tier: 1, maps: [
-			{ name: 'Phlegethon', top: '3:56', good: '5:55', decent: '7:53', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
-			{ name: 'Torajan Jungle', top: '3:53', good: '5:49', decent: '7:46', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
-			{ name: 'Ruins of Viz-Jun', top: '3:30', good: '5:14', decent: '6:59', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-			{ name: 'Ancestral Trial', top: '3:23', good: '5:05', decent: '6:47', elems: [{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Tomb of Zoltun Kulle', top: '3:20', good: '5:01', decent: '6:41', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
-			{ name: 'Shadows of Westmarch', top: '2:34', good: '3:52', decent: '5:08', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
-			{ name: 'Lost Temple', top: '2:20', good: '3:31', decent: '4:41', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] },
-			{ name: 'Fall of Caldeum', top: '2:07', good: '3:10', decent: '4:13', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
+			{ name: 'Phlegethon', top: '3:55', good: '5:55', decent: '7:55', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
+			{ name: 'Torajan Jungle', top: '3:55', good: '5:50', decent: '7:45', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
+			{ name: 'Ruins of Viz-Jun', top: '3:30', good: '5:15', decent: '7:00', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
+			{ name: 'Ancestral Trial', top: '3:25', good: '5:05', decent: '6:45', elems: [{i:5,v:'120',c:'80,200,80'}] },
+			{ name: 'Tomb of Zoltun Kulle', top: '3:20', good: '5:00', decent: '6:40', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
+			{ name: 'Shadows of Westmarch', top: '2:35', good: '3:50', decent: '5:10', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
+			{ name: 'Lost Temple', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] },
+			{ name: 'Fall of Caldeum', top: '2:05', good: '3:10', decent: '4:15', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
 		]}
 	];
 

--- a/maps.html
+++ b/maps.html
@@ -1706,35 +1706,35 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 	// ===== Season 13 (current) =====
 	var mfDataS13 = [
 		{ tier: 3, maps: [
-			{ name: 'Kehjistan Marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-			{ name: 'Bastion Keep', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Arreat Battlefield', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
-			{ name: 'River of Blood', top: '4:00', good: '5:55', decent: '7:55', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Demon Road', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
-			{ name: 'Royal Crypts', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-			{ name: 'Blood Moon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
-			{ name: 'Skovos Stronghold', top: '3:15', good: '4:55', decent: '6:35', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] }
+			{ name: 'Kehjistan Marketplace', top: '4:18', good: '6:28', decent: '8:37', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+			{ name: 'Bastion Keep', top: '4:03', good: '6:05', decent: '8:07', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+			{ name: 'Arreat Battlefield', top: '4:02', good: '6:03', decent: '8:04', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
+			{ name: 'River of Blood', top: '3:58', good: '5:56', decent: '7:55', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+			{ name: 'Demon Road', top: '3:49', good: '5:43', decent: '7:37', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
+			{ name: 'Royal Crypts', top: '3:48', good: '5:43', decent: '7:37', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+			{ name: 'Blood Moon', top: '5:17', good: '7:56', decent: '10:35', elems: [] },
+			{ name: 'Skovos Stronghold', top: '3:17', good: '4:55', decent: '6:34', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] }
 		]},
 		{ tier: 2, maps: [
-			{ name: 'Canyon of Sescheron', top: '4:15', good: '6:20', decent: '8:30', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
-			{ name: 'Halls of Torture', top: '3:30', good: '5:15', decent: '7:05', elems: [] },
-			{ name: "Horazon's Memory", top: '3:20', good: '5:05', decent: '6:45', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Ashen Plains', top: '3:20', good: '5:00', decent: '6:35', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Throne of Insanity', top: '3:00', good: '4:25', decent: '5:55', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Sewers of Harrogath', top: '2:40', good: '4:05', decent: '5:25', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
-			{ name: 'Sanatorium', top: '2:35', good: '3:50', decent: '5:05', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Ruined Cistern', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
-			{ name: 'Pandemonium Citadel', top: '2:10', good: '3:15', decent: '4:25', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
+			{ name: 'Canyon of Sescheron', top: '4:52', good: '7:18', decent: '9:44', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
+			{ name: 'Halls of Torture', top: '4:03', good: '6:04', decent: '8:06', elems: [] },
+			{ name: "Horazon's Memory", top: '3:52', good: '5:49', decent: '7:45', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+			{ name: 'Ashen Plains', top: '3:48', good: '5:42', decent: '7:35', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+			{ name: 'Throne of Insanity', top: '3:24', good: '5:06', decent: '6:48', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+			{ name: 'Sewers of Harrogath', top: '3:06', good: '4:39', decent: '6:12', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
+			{ name: 'Sanatorium', top: '2:56', good: '4:25', decent: '5:53', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
+			{ name: 'Ruined Cistern', top: '2:40', good: '4:01', decent: '5:20', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
+			{ name: 'Pandemonium Citadel', top: '2:31', good: '3:47', decent: '5:02', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
 		]},
 		{ tier: 1, maps: [
-			{ name: 'Phlegethon', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
-			{ name: 'Torajan Jungle', top: '4:00', good: '6:00', decent: '7:55', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
-			{ name: 'Ruins of Viz-Jun', top: '3:35', good: '5:20', decent: '7:10', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-			{ name: 'Ancestral Trial', top: '3:30', good: '5:15', decent: '6:55', elems: [{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Tomb of Zoltun Kulle', top: '3:25', good: '5:10', decent: '6:50', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
-			{ name: 'Shadows of Westmarch', top: '2:40', good: '3:55', decent: '5:15', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
-			{ name: 'Lost Temple', top: '2:25', good: '3:35', decent: '4:45', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] },
-			{ name: 'Fall of Caldeum', top: '2:10', good: '3:15', decent: '4:20', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
+			{ name: 'Phlegethon', top: '3:56', good: '5:55', decent: '7:53', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
+			{ name: 'Torajan Jungle', top: '3:53', good: '5:49', decent: '7:46', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
+			{ name: 'Ruins of Viz-Jun', top: '3:30', good: '5:14', decent: '6:59', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
+			{ name: 'Ancestral Trial', top: '3:23', good: '5:05', decent: '6:47', elems: [{i:5,v:'120',c:'80,200,80'}] },
+			{ name: 'Tomb of Zoltun Kulle', top: '3:20', good: '5:01', decent: '6:41', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
+			{ name: 'Shadows of Westmarch', top: '2:34', good: '3:52', decent: '5:08', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
+			{ name: 'Lost Temple', top: '2:20', good: '3:31', decent: '4:41', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] },
+			{ name: 'Fall of Caldeum', top: '2:07', good: '3:10', decent: '4:13', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
 		]}
 	];
 

--- a/solo.html
+++ b/solo.html
@@ -1399,35 +1399,35 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		var soloMapDataS13 = [
 			{ tier: 3, maps: [
-				{ name: 'Kehjistan Marketplace', slug: 'marketplace', top: '4:18', good: '6:28', decent: '8:37', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-				{ name: 'Bastion Keep', slug: 'bastion', top: '4:03', good: '6:05', decent: '8:07', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', top: '4:02', good: '6:03', decent: '8:04', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
-				{ name: 'River of Blood', slug: 'riverblood', top: '3:58', good: '5:56', decent: '7:55', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Demon Road', slug: 'demonroad', top: '3:49', good: '5:43', decent: '7:37', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
-				{ name: 'Royal Crypts', slug: 'royalcrypts', top: '3:48', good: '5:43', decent: '7:37', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:17', good: '7:56', decent: '10:35', elems: [] },
-				{ name: 'Skovos Stronghold', slug: 'skovos', top: '3:17', good: '4:55', decent: '6:34', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] }
+				{ name: 'Kehjistan Marketplace', slug: 'marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+				{ name: 'Bastion Keep', slug: 'bastion', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
+				{ name: 'River of Blood', slug: 'riverblood', top: '4:00', good: '5:55', decent: '7:55', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Demon Road', slug: 'demonroad', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
+				{ name: 'Royal Crypts', slug: 'royalcrypts', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
+				{ name: 'Skovos Stronghold', slug: 'skovos', top: '3:15', good: '4:55', decent: '6:35', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] }
 			]},
 			{ tier: 2, maps: [
-				{ name: 'Canyon of Sescheron', slug: 'canyon', top: '4:52', good: '7:18', decent: '9:44', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
-				{ name: 'Halls of Torture', slug: 'hallsoftorture', top: '4:03', good: '6:04', decent: '8:06', elems: [] },
-				{ name: "Horazon's Memory", slug: 'horazonsmemory', top: '3:52', good: '5:49', decent: '7:45', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Ashen Plains', slug: 'ashen', top: '3:48', good: '5:42', decent: '7:35', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Throne of Insanity', slug: 'throne', top: '3:24', good: '5:06', decent: '6:48', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Sewers of Harrogath', slug: 'sewers', top: '3:06', good: '4:39', decent: '6:12', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
-				{ name: 'Sanatorium', slug: 'sanatorium', top: '2:56', good: '4:25', decent: '5:53', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Ruined Cistern', slug: 'cistern', top: '2:40', good: '4:01', decent: '5:20', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
-				{ name: 'Pandemonium Citadel', slug: 'citadel', top: '2:31', good: '3:47', decent: '5:02', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
+				{ name: 'Canyon of Sescheron', slug: 'canyon', top: '4:50', good: '7:20', decent: '9:45', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
+				{ name: 'Halls of Torture', slug: 'hallsoftorture', top: '4:05', good: '6:05', decent: '8:05', elems: [] },
+				{ name: "Horazon's Memory", slug: 'horazonsmemory', top: '3:50', good: '5:50', decent: '7:45', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'Ashen Plains', slug: 'ashen', top: '3:50', good: '5:40', decent: '7:35', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Throne of Insanity', slug: 'throne', top: '3:25', good: '5:05', decent: '6:50', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'Sewers of Harrogath', slug: 'sewers', top: '3:05', good: '4:40', decent: '6:10', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
+				{ name: 'Sanatorium', slug: 'sanatorium', top: '2:55', good: '4:25', decent: '5:55', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Ruined Cistern', slug: 'cistern', top: '2:40', good: '4:00', decent: '5:20', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
+				{ name: 'Pandemonium Citadel', slug: 'citadel', top: '2:30', good: '3:45', decent: '5:00', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
 			]},
 			{ tier: 1, maps: [
-				{ name: 'Phlegethon', slug: 'phlegethon', top: '3:56', good: '5:55', decent: '7:53', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
-				{ name: 'Torajan Jungle', slug: 'torajanjungle', top: '3:53', good: '5:49', decent: '7:46', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
-				{ name: 'Ruins of Viz-Jun', slug: 'ruinsofvizjun', top: '3:30', good: '5:14', decent: '6:59', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-				{ name: 'Ancestral Trial', slug: 'ancestral', top: '3:23', good: '5:05', decent: '6:47', elems: [{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Tomb of Zoltun Kulle', slug: 'zoltun', top: '3:20', good: '5:01', decent: '6:41', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
-				{ name: 'Shadows of Westmarch', slug: 'westmarch', top: '2:34', good: '3:52', decent: '5:08', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
-				{ name: 'Lost Temple', slug: 'losttemple', top: '2:20', good: '3:31', decent: '4:41', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] },
-				{ name: 'Fall of Caldeum', slug: 'caldeum', top: '2:07', good: '3:10', decent: '4:13', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
+				{ name: 'Phlegethon', slug: 'phlegethon', top: '3:55', good: '5:55', decent: '7:55', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
+				{ name: 'Torajan Jungle', slug: 'torajanjungle', top: '3:55', good: '5:50', decent: '7:45', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
+				{ name: 'Ruins of Viz-Jun', slug: 'ruinsofvizjun', top: '3:30', good: '5:15', decent: '7:00', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
+				{ name: 'Ancestral Trial', slug: 'ancestral', top: '3:25', good: '5:05', decent: '6:45', elems: [{i:5,v:'120',c:'80,200,80'}] },
+				{ name: 'Tomb of Zoltun Kulle', slug: 'zoltun', top: '3:20', good: '5:00', decent: '6:40', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
+				{ name: 'Shadows of Westmarch', slug: 'westmarch', top: '2:35', good: '3:50', decent: '5:10', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
+				{ name: 'Lost Temple', slug: 'losttemple', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] },
+				{ name: 'Fall of Caldeum', slug: 'caldeum', top: '2:05', good: '3:10', decent: '4:15', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
 			]}
 		];
 

--- a/solo.html
+++ b/solo.html
@@ -1399,35 +1399,35 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		var soloMapDataS13 = [
 			{ tier: 3, maps: [
-				{ name: 'Kehjistan Marketplace', slug: 'marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-				{ name: 'Bastion Keep', slug: 'bastion', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
-				{ name: 'River of Blood', slug: 'riverblood', top: '4:00', good: '5:55', decent: '7:55', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Demon Road', slug: 'demonroad', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
-				{ name: 'Royal Crypts', slug: 'royalcrypts', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
-				{ name: 'Skovos Stronghold', slug: 'skovos', top: '3:15', good: '4:55', decent: '6:35', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] }
+				{ name: 'Kehjistan Marketplace', slug: 'marketplace', top: '4:18', good: '6:28', decent: '8:37', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+				{ name: 'Bastion Keep', slug: 'bastion', top: '4:03', good: '6:05', decent: '8:07', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', top: '4:02', good: '6:03', decent: '8:04', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
+				{ name: 'River of Blood', slug: 'riverblood', top: '3:58', good: '5:56', decent: '7:55', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Demon Road', slug: 'demonroad', top: '3:49', good: '5:43', decent: '7:37', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
+				{ name: 'Royal Crypts', slug: 'royalcrypts', top: '3:48', good: '5:43', decent: '7:37', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:17', good: '7:56', decent: '10:35', elems: [] },
+				{ name: 'Skovos Stronghold', slug: 'skovos', top: '3:17', good: '4:55', decent: '6:34', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] }
 			]},
 			{ tier: 2, maps: [
-				{ name: 'Canyon of Sescheron', slug: 'canyon', top: '4:15', good: '6:20', decent: '8:30', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
-				{ name: 'Halls of Torture', slug: 'hallsoftorture', top: '3:30', good: '5:15', decent: '7:05', elems: [] },
-				{ name: "Horazon's Memory", slug: 'horazonsmemory', top: '3:20', good: '5:05', decent: '6:45', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Ashen Plains', slug: 'ashen', top: '3:20', good: '5:00', decent: '6:35', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Throne of Insanity', slug: 'throne', top: '3:00', good: '4:25', decent: '5:55', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Sewers of Harrogath', slug: 'sewers', top: '2:40', good: '4:05', decent: '5:25', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
-				{ name: 'Sanatorium', slug: 'sanatorium', top: '2:35', good: '3:50', decent: '5:05', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Ruined Cistern', slug: 'cistern', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
-				{ name: 'Pandemonium Citadel', slug: 'citadel', top: '2:10', good: '3:15', decent: '4:25', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
+				{ name: 'Canyon of Sescheron', slug: 'canyon', top: '4:52', good: '7:18', decent: '9:44', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
+				{ name: 'Halls of Torture', slug: 'hallsoftorture', top: '4:03', good: '6:04', decent: '8:06', elems: [] },
+				{ name: "Horazon's Memory", slug: 'horazonsmemory', top: '3:52', good: '5:49', decent: '7:45', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'Ashen Plains', slug: 'ashen', top: '3:48', good: '5:42', decent: '7:35', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Throne of Insanity', slug: 'throne', top: '3:24', good: '5:06', decent: '6:48', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'Sewers of Harrogath', slug: 'sewers', top: '3:06', good: '4:39', decent: '6:12', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
+				{ name: 'Sanatorium', slug: 'sanatorium', top: '2:56', good: '4:25', decent: '5:53', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Ruined Cistern', slug: 'cistern', top: '2:40', good: '4:01', decent: '5:20', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
+				{ name: 'Pandemonium Citadel', slug: 'citadel', top: '2:31', good: '3:47', decent: '5:02', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
 			]},
 			{ tier: 1, maps: [
-				{ name: 'Phlegethon', slug: 'phlegethon', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
-				{ name: 'Torajan Jungle', slug: 'torajanjungle', top: '4:00', good: '6:00', decent: '7:55', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
-				{ name: 'Ruins of Viz-Jun', slug: 'ruinsofvizjun', top: '3:35', good: '5:20', decent: '7:10', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-				{ name: 'Ancestral Trial', slug: 'ancestral', top: '3:30', good: '5:15', decent: '6:55', elems: [{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Tomb of Zoltun Kulle', slug: 'zoltun', top: '3:25', good: '5:10', decent: '6:50', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
-				{ name: 'Shadows of Westmarch', slug: 'westmarch', top: '2:40', good: '3:55', decent: '5:15', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
-				{ name: 'Lost Temple', slug: 'losttemple', top: '2:25', good: '3:35', decent: '4:45', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] },
-				{ name: 'Fall of Caldeum', slug: 'caldeum', top: '2:10', good: '3:15', decent: '4:20', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
+				{ name: 'Phlegethon', slug: 'phlegethon', top: '3:56', good: '5:55', decent: '7:53', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
+				{ name: 'Torajan Jungle', slug: 'torajanjungle', top: '3:53', good: '5:49', decent: '7:46', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
+				{ name: 'Ruins of Viz-Jun', slug: 'ruinsofvizjun', top: '3:30', good: '5:14', decent: '6:59', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
+				{ name: 'Ancestral Trial', slug: 'ancestral', top: '3:23', good: '5:05', decent: '6:47', elems: [{i:5,v:'120',c:'80,200,80'}] },
+				{ name: 'Tomb of Zoltun Kulle', slug: 'zoltun', top: '3:20', good: '5:01', decent: '6:41', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
+				{ name: 'Shadows of Westmarch', slug: 'westmarch', top: '2:34', good: '3:52', decent: '5:08', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
+				{ name: 'Lost Temple', slug: 'losttemple', top: '2:20', good: '3:31', decent: '4:41', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] },
+				{ name: 'Fall of Caldeum', slug: 'caldeum', top: '2:07', good: '3:10', decent: '4:13', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
 			]}
 		];
 


### PR DESCRIPTION
## Summary
- Refreshed Season 13 Solo/MF top/good/decent clear times in `mfDataS13` (maps.html) and `soloMapDataS13` (solo.html) from new dataset
- Decimal-minute values were converted to existing `mm:ss` string format
- 98 EXP and no-penalty EXP data matched existing values and were left unchanged

## Test plan
- [ ] Open `solo.html`, open the Tier Criteria modal on Season 13, verify all 25 maps show the refreshed top/good/decent times
- [ ] Open `maps.html`, open the Map Times modal on Season 13 with "Magic Find" mode selected, verify times match
- [ ] Confirm the "Calculate Your Times" feature still works (ratio math depends on `mm:ss` parsing)
- [ ] Confirm Season 12 toggle still shows unchanged S12 archive values

🤖 Generated with [Claude Code](https://claude.com/claude-code)