### PR TITLE
Order class-build links: video guides, planner/gear, map clears, submit

### DIFF
--- a/solo.html
+++ b/solo.html
@@ -844,26 +844,34 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 	  tdLinks.colSpan = 5;
 
 	  {
-		let linksHtml = '';
+		// Order: video guides, then planner/gear, then map-clear videos, then submit.
+		let videoGuideHtml = '';
+		let plannerGearHtml = '';
+		let mapClearHtml = '';
 		build.links.forEach(function(link) {
 		  if (link.type === 'planner') {
-			linksHtml += '<a target="_blank" href="' + link.url + '"><span class="badge rounded-pill text-bg-primary">' + escapeHtml(link.label) + '</span></a>\n';
+			plannerGearHtml += '<a target="_blank" href="' + link.url + '"><span class="badge rounded-pill text-bg-primary">' + escapeHtml(link.label) + '</span></a>\n';
 		  } else if (link.type === 'guide') {
-			linksHtml += '<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2" href="' + link.url + '" rel="noreferrer" target="_blank">' + escapeHtml(link.label) + '</a>\n';
+			plannerGearHtml += '<a class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2" href="' + link.url + '" rel="noreferrer" target="_blank">' + escapeHtml(link.label) + '</a>\n';
 		  } else if (link.type === 'video') {
 			var isGuide = (link.label === 'Starter Guide' || link.label.indexOf('Starter Guide ') === 0 || link.label.indexOf('Build Guide') === 0);
 			var videoPrefix = isGuide ? 'Video' : ('Season ' + (link.season || 12) + ' Video');
-			linksHtml += '<a target="_blank" href="' + link.url + '"><span class="badge rounded-pill text-bg-success" style="font-size:0.55em;line-height:1.3">' + videoPrefix + '<br/>' + escapeHtml(link.label) + '</span></a>\n';
+			var videoHtml = '<a target="_blank" href="' + link.url + '"><span class="badge rounded-pill text-bg-success" style="font-size:0.55em;line-height:1.3">' + videoPrefix + '<br/>' + escapeHtml(link.label) + '</span></a>\n';
+			if (isGuide) {
+			  videoGuideHtml += videoHtml;
+			} else {
+			  mapClearHtml += videoHtml;
+			}
 		  }
 		});
 		build.notes.forEach(function(note) {
-		  linksHtml += '<span class="badge rounded-pill text-bg-secondary">' + escapeHtml(note) + '</span>\n';
+		  plannerGearHtml += '<span class="badge rounded-pill text-bg-secondary">' + escapeHtml(note) + '</span>\n';
 		});
 		var submitTitle = encodeURIComponent(className + ' - ' + build.buildName + ' Map Clear');
 		var submitBody = encodeURIComponent('Build: ' + className + ' - ' + build.buildName + '\nMap: \nClear Time: \nNotes: ');
 		var submitUrl = 'https://github.com/Maaaaaarrk/Hiim-PD2-Resources/issues/new?title=' + submitTitle + '&body=' + submitBody;
-		linksHtml += '<a target="_blank" href="' + submitUrl + '" class="btn btn-outline-success btn-sm ms-1" style="font-size:0.65em;padding:2px 6px;">Submit Map Clear</a>\n';
-		tdLinks.innerHTML = linksHtml;
+		var submitHtml = '<a target="_blank" href="' + submitUrl + '" class="btn btn-outline-success btn-sm ms-1" style="font-size:0.65em;padding:2px 6px;">Submit Map Clear</a>\n';
+		tdLinks.innerHTML = videoGuideHtml + plannerGearHtml + mapClearHtml + submitHtml;
 	  }
 	  tr.appendChild(tdLinks);
 


### PR DESCRIPTION
## Summary
In `solo.html`'s `renderClassBuildRow` (non-starter per-class builds), links in the right-hand column currently render in whatever order they appear in `solo-data.json`. This PR reorders them into consistent buckets:

1. **Video build guides** (green pills whose label starts with `Build Guide` / `Starter Guide`)
2. **Planner & gear guide links** (blue planner pills and bordered guide links — notes ride with this group since they describe the build)
3. **Map clear videos** (green `Season N Video` pills)
4. **Submit Map Clear** button (always last)

Classification reuses the existing `isGuide` heuristic (`label === 'Starter Guide'`, or prefixes `'Starter Guide '`/`'Build Guide'`) — no changes to the link rendering HTML or the underlying data schema. Starter builds (`renderStarterRow`) are unchanged.

Example visible impact: Barbarian > Travbarb currently shows `[End-game Planner] [Build Guide (1:11:37)]`; after this PR it shows `[Build Guide (1:11:37)] [End-game Planner]`.

## Test plan
- [ ] Open `solo.html` in a browser and scroll through each non-starter class
- [ ] Verify builds with a Build Guide video show the Video Guide pill first
- [ ] Verify builds with both planners and map-clear videos show planners before map clears
- [ ] Verify the `Submit Map Clear` button always renders last
- [ ] Starter section (top of page) is visually unchanged

*Not verified in a browser from this environment (static site, no server).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)