### PR TITLE
Fix #178: Add Sorc Nova Build Guide video (philanthropy777)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -535,6 +535,12 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=4O__wTyY5Uw&t=102s",
             "label": "Throne of Insanity (3:49)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=5002s",
+            "label": "Build Guide (47:18)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.js
+++ b/solo-data.js
@@ -537,7 +537,7 @@ window.soloData = {
             "type": "video"
           },
           {
-            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=5002s",
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=2838s",
             "label": "Build Guide (47:18)",
             "type": "video",
             "season": 13

--- a/solo-data.json
+++ b/solo-data.json
@@ -537,7 +537,7 @@
             "type": "video"
           },
           {
-            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=5002s",
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=2838s",
             "label": "Build Guide (47:18)",
             "type": "video",
             "season": 13

--- a/solo-data.json
+++ b/solo-data.json
@@ -535,6 +535,12 @@
             "url": "https://www.youtube.com/watch?v=4O__wTyY5Uw&t=102s",
             "label": "Throne of Insanity (3:49)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=5002s",
+            "label": "Build Guide (47:18)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []


### PR DESCRIPTION
Closes #178

## Summary
Adds a Build Guide video link to the Sorceress > Nova entry in the Solo tier list, submitted by @philanthropy777 via the community issue form.

- **Class / Build:** Sorceress > Nova
- **Video:** https://www.youtube.com/watch?v=7AAuplKljvg&t=5002s
- **Label:** Build Guide (47:18)
- **Season:** 13

## Files changed
- `solo-data.json` — appended new link object to Nova's `links[]`
- `solo-data.js` — mirrored the same change (per `CLAUDE.md`)
- `updatedDate` was already `"April 23rd 2026"` in both files; no change needed.

## Curation note
Submitter also suggested the build be re-tiered to Top — not applied; left as a curation decision for Maaaaaarrk. (Current tier is already `"Top"`, so no action appears needed either way, but flagging for visibility.)

## Test plan
- [ ] Open `solo.html` locally and confirm the new Build Guide link appears under Sorceress > Nova
- [ ] Click through to verify the YouTube URL + timestamp resolve correctly