### PR TITLE
Fix #180: Add Dclone Jab Build Guide and Submit Video buttons on boss.html

### DIFF
--- a/.github/ISSUE_TEMPLATE/boss-kill-submission.yml
+++ b/.github/ISSUE_TEMPLATE/boss-kill-submission.yml
@@ -1,0 +1,49 @@
+name: Boss Kill Submission
+description: Submit a boss-kill video to be added to the boss fight tier list
+labels: ["boss kill submission"]
+body:
+  - type: dropdown
+    id: boss
+    attributes:
+      label: Boss
+      options:
+        - Vision of Terror - Diablo-Clone
+        - Voidstone - Rathma
+        - Shadow of Hatred - Lucion
+    validations:
+      required: true
+  - type: dropdown
+    id: class
+    attributes:
+      label: Class
+      options:
+        - Sorceress
+        - Druid
+        - Assassin
+        - Barbarian
+        - Amazon
+        - Necromancer
+        - Paladin
+    validations:
+      required: true
+  - type: input
+    id: build-name
+    attributes:
+      label: Build Name
+      placeholder: "e.g. Jab/Fend"
+    validations:
+      required: true
+  - type: input
+    id: video-url
+    attributes:
+      label: Video URL
+      description: Link to the boss-kill video. Include a `&t=SECONDSs` timestamp in the URL so it jumps to the fight.
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any relevant notes, gear requirements, or context for this kill.
+    validations:
+      required: false

--- a/boss.html
+++ b/boss.html
@@ -421,7 +421,7 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 			<div class="alert alert-danger" role="alert">
 				<h3>"Easy/Moderate/Hard" are relative terms when it comes to T2 boss fights.<br/>
 					You must be well-versed in the fight to even stand a chance on an Easy build.<br/>
-					Season 13 &mdash; Updated &mdash; April 22nd 2026</h3>
+					Season 13 &mdash; Updated &mdash; April 23rd 2026</h3>
 			</div>
 		</td>
 	</tr>
@@ -1013,6 +1013,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 			<td>Jab</td>
 			<td><span class="badge rounded-pill text-bg-success">Easy</span></td>
 			<td>
+				<a target="_blank" href="https://www.youtube.com/watch?v=ndPULNORgXM&t=3613s"><span class="badge rounded-pill text-bg-success" style="font-size:0.55em;line-height:1.3">Video<br/>Build Guide (1:00:13)</span></a>
 			</td>
 		</tr>
 		<tr>
@@ -2254,6 +2255,68 @@ const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstra
 			}
 		});
 	}
+</script>
+<script>
+	// Inject "Submit Video" buttons into every empty 3rd-column cell in each
+	// boss section so users can open a pre-filled boss-kill-submission issue.
+	(function injectSubmitButtons() {
+		const BOSS_NAMES = {
+			generalists: 'Vision of Terror - Diablo-Clone',
+			physical:    'Voidstone - Rathma',
+			elemental:   'Shadow of Hatred - Lucion'
+		};
+		const ISSUE_URL = 'https://github.com/Maaaaaarrk/Hiim-PD2-Resources/issues/new';
+
+		function classNameFromThead(thead) {
+			if (!thead) return null;
+			const text = (thead.textContent || '').replace(/\s+/g, ' ').trim();
+			const m = text.match(/(Sorceress|Druid|Assassin|Barbarian|Amazon|Necromancer|Paladin)\s+Builds/);
+			return m ? m[1] : null;
+		}
+
+		function run() {
+			Object.keys(BOSS_NAMES).forEach(function(sectionId) {
+				const section = document.getElementById(sectionId);
+				if (!section) return;
+				const bossName = BOSS_NAMES[sectionId];
+				const tbodies = section.querySelectorAll('tbody');
+				tbodies.forEach(function(tbody) {
+					// Look backwards through previous siblings for the nearest thead.
+					let prev = tbody.previousElementSibling;
+					while (prev && prev.tagName !== 'THEAD') prev = prev.previousElementSibling;
+					const className = classNameFromThead(prev);
+					if (!className) return; // defensive: skip if we can't derive the class
+					const rows = tbody.querySelectorAll('tr');
+					rows.forEach(function(tr) {
+						if (!tr.children[0] || !tr.children[2]) return;
+						const buildName = (tr.children[0].textContent || '').trim();
+						if (!buildName) return;
+						const cell = tr.children[2];
+						if (cell.innerHTML.trim() !== '') return; // already has content
+						const url = ISSUE_URL
+							+ '?template=boss-kill-submission.yml'
+							+ '&boss=' + encodeURIComponent(bossName)
+							+ '&class=' + encodeURIComponent(className)
+							+ '&build-name=' + encodeURIComponent(buildName);
+						const a = document.createElement('a');
+						a.target = '_blank';
+						a.href = url;
+						a.className = 'btn btn-outline-success btn-sm';
+						a.style.fontSize = '0.65em';
+						a.style.padding = '2px 6px';
+						a.textContent = 'Submit Video';
+						cell.appendChild(a);
+					});
+				});
+			});
+		}
+
+		if (document.readyState === 'loading') {
+			document.addEventListener('DOMContentLoaded', run);
+		} else {
+			run();
+		}
+	})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #180

## Summary

- Adds `.github/ISSUE_TEMPLATE/boss-kill-submission.yml` — a new GitHub issue form for submitting boss-kill videos (boss / class / build-name / video-url / notes).
- Adds the Jab/Fend Amazon Dclone build guide video (timestamp 1:00:13) inline in the `#generalists` > Amazon > Jab row on `boss.html`, matching the solo-data "Video / Build Guide (H:MM:SS)" pill style.
- Adds a small JS injector at the end of `boss.html` that walks each boss section (`#generalists`, `#physical`, `#elemental`), reads the class name from each preceding `<thead>` (stripping `" Builds"` from the header text for robustness — IDs have inconsistent `1/2/3` suffixes), and drops a `Submit Video` button into every otherwise-empty 3rd-column cell. Each button deep-links to the new issue template with boss, class, and build-name pre-filled via query string.
- Bumps the `Updated` timestamp on `boss.html` to April 23rd 2026 per `CLAUDE.md`.

## Curation notes

- Submitter **philanthropy777** suggested tier **Top** for Jab/Fend Amazon T2 Dclone (currently listed as **Decent** on the solo tier list). **Not applied here** — left as a curation decision for @Maaaaaarrk to handle separately if desired.
- The Build Guide video already existed on the solo-data Jab/Fend Amazon entry. This PR only adds it to the Dclone tier in `boss.html`, as the submitter explicitly requested ("We could implement the T2 Dclone Video showcase in the Bossing Tierlist").
- Scope is `boss.html` only — `boss12.html` is deliberately untouched.

## Test plan

- [ ] Open `boss.html` and confirm the Dclone > Amazon > Jab row shows a green "Video / Build Guide (1:00:13)" pill linking to `https://www.youtube.com/watch?v=ndPULNORgXM&t=3613s`.
- [ ] Confirm every *other* row (all 3 bosses × all 7 classes) shows a "Submit Video" outline button in its previously-empty cell.
- [ ] Click a Submit Video button on a Rathma > Sorceress > Meteor row and verify the opened GitHub issue has Boss = "Voidstone - Rathma", Class = "Sorceress", Build Name = "Meteor" pre-filled in the new form.
- [ ] Confirm the "Updated — April 23rd 2026" banner is shown at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)