### PR TITLE
Fix #184: Add Copy Image button to wheel (solo.html, group.html)

### DIFF
--- a/group-data.js
+++ b/group-data.js
@@ -1,6 +1,6 @@
 window.groupData = {
   "season": 13,
-  "updatedDate": "April 23rd 2026",
+  "updatedDate": "April 24th 2026",
   "bannerText": "Updated",
   "generalists": {
     "title": "Public Map Focused P8 Mapping",

--- a/group-data.json
+++ b/group-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "April 23rd 2026",
+  "updatedDate": "April 24th 2026",
   "bannerText": "Updated",
   "generalists": {
     "title": "Public Map Focused P8 Mapping",

--- a/group.html
+++ b/group.html
@@ -896,6 +896,10 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 					<button class="btn btn-primary btn-lg px-5" id="spinBtn" onclick="spinWheel()">SPIN</button>
 				</div>
 				<div id="wheelResult" class="mt-3 fs-3 fw-bold" style="min-height:2.5rem;"></div>
+				<div class="mt-2">
+					<button class="btn btn-outline-success btn-sm" id="copyWheelImageBtn" onclick="copyWheelImage()">&#128247; Copy Image</button>
+					<div id="copyWheelImageStatus" class="small text-muted mt-1" style="min-height:1.2rem;"></div>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -922,6 +926,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
         integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y"
         src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js">-
 </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 <script src="group-data.js"></script>
 <script>
 
@@ -1329,6 +1334,8 @@ function openWheelModal() {
   if (wheelAnimId) { cancelAnimationFrame(wheelAnimId); wheelAnimId = null; }
   document.getElementById('wheelResult').textContent = '';
   document.getElementById('spinBtn').disabled = false;
+  var copyStatus = document.getElementById('copyWheelImageStatus');
+  if (copyStatus) { copyStatus.textContent = ''; copyStatus.className = 'small text-muted mt-1'; }
   drawWheel();
   var modal = new bootstrap.Modal(document.getElementById('wheelModal'));
   modal.show();
@@ -1383,6 +1390,7 @@ function fireConfetti() {
       gravity: 0.12+Math.random()*0.08, opacity: 1, shape: Math.random()>0.5?'rect':'circle' });
   }
   var canvas = document.createElement('canvas'); canvas.width = w; canvas.height = h;
+  canvas.id = 'wheelConfettiCanvas';
   canvas.style.cssText = 'position:fixed;top:0;left:0;pointer-events:none;z-index:99999;';
   document.body.appendChild(canvas);
   var ctx = canvas.getContext('2d'); var startTime = performance.now(); var duration = 6000;
@@ -1402,6 +1410,84 @@ function fireConfetti() {
     requestAnimationFrame(animateConfetti);
   }
   requestAnimationFrame(animateConfetti);
+}
+
+// ── Copy Wheel Image ──
+// Captures the wheel modal content (wheel, pointer, SPIN button, result) plus any
+// currently-playing confetti overlay, and writes a PNG to the clipboard.
+// Falls back to a PNG download if the Clipboard Image API is unavailable.
+function copyWheelImage() {
+  var statusEl = document.getElementById('copyWheelImageStatus');
+  var btn = document.getElementById('copyWheelImageBtn');
+  if (typeof html2canvas !== 'function') {
+    statusEl.textContent = 'html2canvas failed to load.';
+    statusEl.className = 'small text-danger mt-1';
+    return;
+  }
+  var modalContent = document.querySelector('#wheelModal .modal-content');
+  if (!modalContent) return;
+  btn.disabled = true;
+  statusEl.textContent = 'Capturing…';
+  statusEl.className = 'small text-muted mt-1';
+
+  html2canvas(modalContent, { backgroundColor: null, useCORS: true, logging: false }).then(function(modalCanvas) {
+    var confetti = document.getElementById('wheelConfettiCanvas');
+    var finalCanvas = modalCanvas;
+    if (confetti) {
+      var rect = modalContent.getBoundingClientRect();
+      var composed = document.createElement('canvas');
+      composed.width = modalCanvas.width;
+      composed.height = modalCanvas.height;
+      var cctx = composed.getContext('2d');
+      cctx.drawImage(modalCanvas, 0, 0);
+      cctx.drawImage(
+        confetti,
+        rect.left, rect.top, rect.width, rect.height,
+        0, 0, modalCanvas.width, modalCanvas.height
+      );
+      finalCanvas = composed;
+    }
+    finalCanvas.toBlob(function(blob) {
+      if (!blob) {
+        statusEl.textContent = 'Failed to create image.';
+        statusEl.className = 'small text-danger mt-1';
+        btn.disabled = false;
+        return;
+      }
+      if (navigator.clipboard && window.ClipboardItem) {
+        navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+          .then(function() {
+            statusEl.textContent = 'Image copied to clipboard!';
+            statusEl.className = 'small text-success mt-1';
+            btn.disabled = false;
+          })
+          .catch(function() {
+            fallbackDownloadWheelImage(blob, statusEl);
+            btn.disabled = false;
+          });
+      } else {
+        fallbackDownloadWheelImage(blob, statusEl);
+        btn.disabled = false;
+      }
+    }, 'image/png');
+  }).catch(function(err) {
+    statusEl.textContent = 'Capture failed: ' + (err && err.message ? err.message : 'unknown error');
+    statusEl.className = 'small text-danger mt-1';
+    btn.disabled = false;
+  });
+}
+
+function fallbackDownloadWheelImage(blob, statusEl) {
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement('a');
+  a.href = url;
+  a.download = 'pd2-wheel-result.png';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(function() { URL.revokeObjectURL(url); }, 1000);
+  statusEl.textContent = 'Clipboard unavailable — downloaded PNG instead.';
+  statusEl.className = 'small text-warning mt-1';
 }
 </script>
 <div class="modal fade" id="mapTimesModal" tabindex="-1" aria-labelledby="mapTimesModalLabel" aria-hidden="true">

--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "April 23rd 2026",
+  "updatedDate": "April 24th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "April 23rd 2026",
+  "updatedDate": "April 24th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {

--- a/solo.html
+++ b/solo.html
@@ -720,6 +720,10 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 					<button class="btn btn-primary btn-lg px-5" id="spinBtn" onclick="spinWheel()">SPIN</button>
 				</div>
 				<div id="wheelResult" class="mt-3 fs-3 fw-bold" style="min-height:2.5rem;"></div>
+				<div class="mt-2">
+					<button class="btn btn-outline-success btn-sm" id="copyWheelImageBtn" onclick="copyWheelImage()">&#128247; Copy Image</button>
+					<div id="copyWheelImageStatus" class="small text-muted mt-1" style="min-height:1.2rem;"></div>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -737,6 +741,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
         integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y"
         src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js">-
 </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 <script src="solo-data.js"></script>
 <script>
 
@@ -1221,6 +1226,8 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 	  if (wheelAnimId) { cancelAnimationFrame(wheelAnimId); wheelAnimId = null; }
 	  document.getElementById('wheelResult').textContent = '';
 	  document.getElementById('spinBtn').disabled = false;
+	  var copyStatus = document.getElementById('copyWheelImageStatus');
+	  if (copyStatus) { copyStatus.textContent = ''; copyStatus.className = 'small text-muted mt-1'; }
 	  drawWheel();
 	  var modal = new bootstrap.Modal(document.getElementById('wheelModal'));
 	  modal.show();
@@ -1326,6 +1333,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 	  var canvas = document.createElement('canvas');
 	  canvas.width = w;
 	  canvas.height = h;
+	  canvas.id = 'wheelConfettiCanvas';
 	  canvas.style.cssText = 'position:fixed;top:0;left:0;pointer-events:none;z-index:99999;';
 	  document.body.appendChild(canvas);
 	  var ctx = canvas.getContext('2d');
@@ -1369,6 +1377,90 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		requestAnimationFrame(animateConfetti);
 	  }
 	  requestAnimationFrame(animateConfetti);
+	}
+
+	// ── Copy Wheel Image ──
+	// Captures the wheel modal content (wheel, pointer, SPIN button, result) plus any
+	// currently-playing confetti overlay, and writes a PNG to the clipboard.
+	// Falls back to a PNG download if the Clipboard Image API is unavailable
+	// (older browsers, file:// contexts, etc.).
+	function copyWheelImage() {
+	  var statusEl = document.getElementById('copyWheelImageStatus');
+	  var btn = document.getElementById('copyWheelImageBtn');
+	  if (typeof html2canvas !== 'function') {
+		statusEl.textContent = 'html2canvas failed to load.';
+		statusEl.className = 'small text-danger mt-1';
+		return;
+	  }
+	  var modalContent = document.querySelector('#wheelModal .modal-content');
+	  if (!modalContent) return;
+	  btn.disabled = true;
+	  statusEl.textContent = 'Capturing…';
+	  statusEl.className = 'small text-muted mt-1';
+
+	  html2canvas(modalContent, { backgroundColor: null, useCORS: true, logging: false }).then(function(modalCanvas) {
+		// Composite the confetti canvas on top, cropped to the modal's on-screen position.
+		var confetti = document.getElementById('wheelConfettiCanvas');
+		var finalCanvas = modalCanvas;
+		if (confetti) {
+		  var rect = modalContent.getBoundingClientRect();
+		  var composed = document.createElement('canvas');
+		  composed.width = modalCanvas.width;
+		  composed.height = modalCanvas.height;
+		  var cctx = composed.getContext('2d');
+		  cctx.drawImage(modalCanvas, 0, 0);
+		  // Scale factor between html2canvas output and on-screen CSS pixels.
+		  var sx = modalCanvas.width / rect.width;
+		  var sy = modalCanvas.height / rect.height;
+		  // Crop the full-viewport confetti canvas to the modal's CSS rect, then draw scaled.
+		  cctx.drawImage(
+			confetti,
+			rect.left, rect.top, rect.width, rect.height,
+			0, 0, modalCanvas.width, modalCanvas.height
+		  );
+		  finalCanvas = composed;
+		}
+		finalCanvas.toBlob(function(blob) {
+		  if (!blob) {
+			statusEl.textContent = 'Failed to create image.';
+			statusEl.className = 'small text-danger mt-1';
+			btn.disabled = false;
+			return;
+		  }
+		  if (navigator.clipboard && window.ClipboardItem) {
+			navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+			  .then(function() {
+				statusEl.textContent = 'Image copied to clipboard!';
+				statusEl.className = 'small text-success mt-1';
+				btn.disabled = false;
+			  })
+			  .catch(function() {
+				fallbackDownloadWheelImage(blob, statusEl);
+				btn.disabled = false;
+			  });
+		  } else {
+			fallbackDownloadWheelImage(blob, statusEl);
+			btn.disabled = false;
+		  }
+		}, 'image/png');
+	  }).catch(function(err) {
+		statusEl.textContent = 'Capture failed: ' + (err && err.message ? err.message : 'unknown error');
+		statusEl.className = 'small text-danger mt-1';
+		btn.disabled = false;
+	  });
+	}
+
+	function fallbackDownloadWheelImage(blob, statusEl) {
+	  var url = URL.createObjectURL(blob);
+	  var a = document.createElement('a');
+	  a.href = url;
+	  a.download = 'pd2-wheel-result.png';
+	  document.body.appendChild(a);
+	  a.click();
+	  document.body.removeChild(a);
+	  setTimeout(function() { URL.revokeObjectURL(url); }, 1000);
+	  statusEl.textContent = 'Clipboard unavailable — downloaded PNG instead.';
+	  statusEl.className = 'small text-warning mt-1';
 	}
 
 </script>


### PR DESCRIPTION
Closes #184

## Summary

Adds a **Copy Image** action inside the Spin the Wheel modal on both `solo.html` and `group.html`. Clicking it captures the current wheel + pointer + SPIN button + result (winner) and any in-progress confetti animation, and writes the combined PNG to the system clipboard.

## Capture mechanism

- **html2canvas** (pinned `1.4.1`, loaded from cdnjs) captures the `#wheelModal .modal-content` DOM subtree: wheel canvas, pointer triangle, SPIN button, result text, and Copy button itself.
- The confetti is a separate full-viewport `<canvas>` that `fireConfetti()` appends to `document.body` (position: fixed, z-index 99999) — it is **not** inside the wheel modal subtree. Rather than restructure the DOM, the confetti canvas is now tagged with `id="wheelConfettiCanvas"` and, at capture time, its pixels are cropped to the modal's on-screen rect and composited on top of the html2canvas output. This keeps the existing confetti rendering untouched.

## Clipboard + fallback

- Primary path: `navigator.clipboard.write([new ClipboardItem({'image/png': blob})])` — works in modern Chromium, Firefox, and Safari.
- Fallback: if `ClipboardItem` is unavailable or the clipboard write rejects (common on `file://` contexts, older browsers, insecure origins), the blob is offered as a `pd2-wheel-result.png` download via a temporary `<a download>`.
- A small inline status line under the button reports success / fallback / error (no existing toast infra in the repo, so this matches the minimalist house style).

## Files touched

- `solo.html` — added html2canvas CDN `<script>`, Copy Image button, `copyWheelImage` + `fallbackDownloadWheelImage` helpers, tagged confetti canvas with id, cleared copy status on modal reopen.
- `group.html` — same set of changes, mirrored.
- `solo-data.json`, `solo-data.js`, `group-data.json`, `group-data.js` — bumped `updatedDate` to `April 24th 2026` per CLAUDE.md.

## Test plan

- [ ] Open `solo.html` in a modern browser, open the Wheel modal, spin, click Copy Image mid- or post-confetti; paste into an image-accepting target (Discord, Paint, Slack) and confirm the wheel + result + confetti are present.
- [ ] Same on `group.html`.
- [ ] Test fallback by opening the page over `file://` (or a browser without `ClipboardItem`) — expect a PNG download instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)