### PR TITLE
Sort S13 map times descending within each tier

### DIFF
--- a/group.html
+++ b/group.html
@@ -1672,33 +1672,33 @@ function fallbackDownloadWheelImage(blob, statusEl) {
 			['Kehjistan Marketplace', 4.42, 6.62, 8.83],
 			['Arreat Battlefield', 4.23, 6.34, 8.46],
 			['Demon Road', 4.03, 6.05, 8.07],
-			['Royal Crypts', 3.58, 5.37, 7.16],
 			['River of Blood', 3.72, 5.58, 7.43],
 			['Bastion Keep', 3.65, 5.47, 7.30],
+			['Royal Crypts', 3.58, 5.37, 7.16],
 			['Blood Moon', 3.46, 5.19, 6.92],
 			['Skovos Stronghold', 'TBD', 'TBD', 'TBD'],
 			['Kyovoshad', 'TBD', 'TBD', 'TBD']
 		]},
 		{ tier: 2, maps: [
-			['Pandemonium Citadel', 4.92, 7.38, 9.84],
 			['Halls of Torture', 5.32, 7.98, 10.64],
-			['Sanatorium', 4.41, 6.62, 8.82],
+			['Pandemonium Citadel', 4.92, 7.38, 9.84],
 			['Ashen Plains', 4.92, 7.38, 9.84],
-			['Sewers of Harrogath', 3.94, 5.90, 7.87],
-			['Throne of Insanity', 4.00, 6.00, 8.00],
-			['Ruined Cistern', 3.61, 5.41, 7.22],
+			['Sanatorium', 4.41, 6.62, 8.82],
 			['Canyon of Sescheron', 4.19, 6.29, 8.38],
-			["Horazon's Memory", 4.10, 6.14, 8.19]
+			["Horazon's Memory", 4.10, 6.14, 8.19],
+			['Throne of Insanity', 4.00, 6.00, 8.00],
+			['Sewers of Harrogath', 3.94, 5.90, 7.87],
+			['Ruined Cistern', 3.61, 5.41, 7.22]
 		]},
 		{ tier: 1, maps: [
-			['Phlegethon', 4.50, 6.76, 9.01],
-			['Fall of Caldeum', 3.51, 5.26, 7.02],
 			['Torajan Jungle', 4.73, 7.09, 9.46],
+			['Phlegethon', 4.50, 6.76, 9.01],
 			['Ancestral Trial', 4.05, 6.07, 8.10],
-			['Lost Temple', 3.73, 5.59, 7.46],
 			['Ruins of Viz-Jun', 4.01, 6.01, 8.01],
-			['Shadows of Westmarch', 3.17, 4.75, 6.33],
-			['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57]
+			['Lost Temple', 3.73, 5.59, 7.46],
+			['Fall of Caldeum', 3.51, 5.26, 7.02],
+			['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57],
+			['Shadows of Westmarch', 3.17, 4.75, 6.33]
 		]}
 	];
 

--- a/maps.html
+++ b/maps.html
@@ -1707,13 +1707,13 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 	// ===== Season 13 (current) =====
 	var mfDataS13 = [
 		{ tier: 3, maps: [
+			{ name: 'Blood Moon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
 			{ name: 'Kehjistan Marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}] },
 			{ name: 'Bastion Keep', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
 			{ name: 'Arreat Battlefield', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
 			{ name: 'River of Blood', top: '4:00', good: '5:55', decent: '7:55', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
 			{ name: 'Demon Road', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
 			{ name: 'Royal Crypts', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'120',c:'60,140,220'}] },
-			{ name: 'Blood Moon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
 			{ name: 'Skovos Stronghold', top: 'TBD', good: 'TBD', decent: 'TBD', elems: [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}] },
 			{ name: 'Kyovoshad', top: 'TBD', good: 'TBD', decent: 'TBD', elems: [] }
 		]},
@@ -1766,23 +1766,23 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 	var expNoneS13 = [
 		{ tier: 3, maps: [
 			['Kehjistan Marketplace', 4.42, 6.62, 8.83], ['Arreat Battlefield', 4.23, 6.34, 8.46],
-			['Demon Road', 4.03, 6.05, 8.07], ['Royal Crypts', 3.58, 5.37, 7.16],
-			['River of Blood', 3.72, 5.58, 7.43], ['Bastion Keep', 3.65, 5.47, 7.30],
+			['Demon Road', 4.03, 6.05, 8.07], ['River of Blood', 3.72, 5.58, 7.43],
+			['Bastion Keep', 3.65, 5.47, 7.30], ['Royal Crypts', 3.58, 5.37, 7.16],
 			['Blood Moon', 3.46, 5.19, 6.92], ['Skovos Stronghold', 'TBD', 'TBD', 'TBD'],
 			['Kyovoshad', 'TBD', 'TBD', 'TBD']
 		]},
 		{ tier: 2, maps: [
-			['Pandemonium Citadel', 4.92, 7.38, 9.84], ['Halls of Torture', 5.32, 7.98, 10.64],
-			['Sanatorium', 4.41, 6.62, 8.82], ['Ashen Plains', 4.92, 7.38, 9.84],
-			['Sewers of Harrogath', 3.94, 5.90, 7.87], ['Throne of Insanity', 4.00, 6.00, 8.00],
-			['Ruined Cistern', 3.61, 5.41, 7.22], ['Canyon of Sescheron', 4.19, 6.29, 8.38],
-			["Horazon's Memory", 4.10, 6.14, 8.19]
+			['Halls of Torture', 5.32, 7.98, 10.64], ['Pandemonium Citadel', 4.92, 7.38, 9.84],
+			['Ashen Plains', 4.92, 7.38, 9.84], ['Sanatorium', 4.41, 6.62, 8.82],
+			['Canyon of Sescheron', 4.19, 6.29, 8.38], ["Horazon's Memory", 4.10, 6.14, 8.19],
+			['Throne of Insanity', 4.00, 6.00, 8.00], ['Sewers of Harrogath', 3.94, 5.90, 7.87],
+			['Ruined Cistern', 3.61, 5.41, 7.22]
 		]},
 		{ tier: 1, maps: [
-			['Phlegethon', 4.50, 6.76, 9.01], ['Fall of Caldeum', 3.51, 5.26, 7.02],
-			['Torajan Jungle', 4.73, 7.09, 9.46], ['Ancestral Trial', 4.05, 6.07, 8.10],
-			['Lost Temple', 3.73, 5.59, 7.46], ['Ruins of Viz-Jun', 4.01, 6.01, 8.01],
-			['Shadows of Westmarch', 3.17, 4.75, 6.33], ['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57]
+			['Torajan Jungle', 4.73, 7.09, 9.46], ['Phlegethon', 4.50, 6.76, 9.01],
+			['Ancestral Trial', 4.05, 6.07, 8.10], ['Ruins of Viz-Jun', 4.01, 6.01, 8.01],
+			['Lost Temple', 3.73, 5.59, 7.46], ['Fall of Caldeum', 3.51, 5.26, 7.02],
+			['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57], ['Shadows of Westmarch', 3.17, 4.75, 6.33]
 		]}
 	];
 

--- a/solo.html
+++ b/solo.html
@@ -1574,13 +1574,13 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 		var soloMapDataS13 = [
 			{ tier: 3, maps: [
+				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
 				{ name: 'Kehjistan Marketplace', slug: 'marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}] },
 				{ name: 'Bastion Keep', slug: 'bastion', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
 				{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
 				{ name: 'River of Blood', slug: 'riverblood', top: '4:00', good: '5:55', decent: '7:55', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
 				{ name: 'Demon Road', slug: 'demonroad', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
 				{ name: 'Royal Crypts', slug: 'royalcrypts', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'120',c:'60,140,220'}] },
-				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
 				{ name: 'Skovos Stronghold', slug: 'skovos', top: 'TBD', good: 'TBD', decent: 'TBD', elems: [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}] },
 				{ name: 'Kyovoshad', slug: 'kyovoshad', top: 'TBD', good: 'TBD', decent: 'TBD', elems: [] }
 			]},


### PR DESCRIPTION
## Summary
- `mfDataS13` T3 in maps.html and `soloMapDataS13` T3 in solo.html had Blood Moon (5:15) sitting at position 7 instead of first
- `expNoneS13` in maps.html and `dataNoneS13` in group.html were not sorted descending in any tier — switching to the No-Penalty view gave a visibly jumbled order
- All three S13 datasets are now sorted top-descending within each tier, matching the S12 convention

## Test plan
- [ ] Open `maps.html`, open the Map Times modal, verify each tier is sorted top-descending in all three modes (MF, Exp 98, No Penalty)
- [ ] Open `group.html`, open the Map Times modal, verify each tier is sorted top-descending in both modes (Level 98, No Penalty)
- [ ] Open `solo.html`, open the Tier Criteria modal, verify Blood Moon appears first in T3
- [ ] Confirm S12 toggle still shows unchanged S12 archive ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)