### PR TITLE
Fix #188: cz sound alerts now respect zone filter

### DIFF
--- a/cz.html
+++ b/cz.html
@@ -478,7 +478,7 @@ setInterval(function() {
   if (lastZoneTs === null) { lastZoneTs = currentZoneTs; return; }
   if (currentZoneTs !== lastZoneTs) {
     lastZoneTs = currentZoneTs;
-    playNotificationSound();
+    if (isZoneVisible(getZone(now).idx)) playNotificationSound();
   }
 }, 1000);
 })();


### PR DESCRIPTION
## Summary
- The 1s setInterval at cz.html:474 fired `playNotificationSound()` on every 15-minute rotation tick regardless of the user's act/zone/resistance filter.
- Now wraps the call in `if (isZoneVisible(getZone(now).idx))` so the chime only plays when the just-rotated zone matches the same filter the visual list uses (empty filter = no chime, mirroring the "No zones match your current filters." UI state).

Closes #188

## Test plan
- [ ] Load cz.html with `#zones=...` selecting only inactive zones — chime should NOT fire
- [ ] Load cz.html with `#zones=...` matching a currently active CZ — chime SHOULD fire
- [ ] Toggle Sound: OFF — no chime regardless of filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)