### PR TITLE
Add MF Elite Skip variant; consolidate map data into shared maps-data.js

### DIFF
--- a/group-data.js
+++ b/group-data.js
@@ -1,6 +1,6 @@
 window.groupData = {
   "season": 13,
-  "updatedDate": "April 24th 2026",
+  "updatedDate": "April 29th 2026",
   "bannerText": "Updated",
   "generalists": {
     "title": "Public Map Focused P8 Mapping",

--- a/group-data.json
+++ b/group-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "April 24th 2026",
+  "updatedDate": "April 29th 2026",
   "bannerText": "Updated",
   "generalists": {
     "title": "Public Map Focused P8 Mapping",

--- a/group.html
+++ b/group.html
@@ -928,6 +928,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 <script src="group-data.js"></script>
+<script src="maps-data.js"></script>
 <script>
 
 const classSvgs = {
@@ -1562,147 +1563,21 @@ function fallbackDownloadWheelImage(blob, statusEl) {
 		'Fall of Caldeum': 'caldeum', 'Shadows of Westmarch': 'westmarch'
 	};
 
-	// ===== Season 12 archive =====
-	var data98S12 = [
-		{ tier: 3, maps: [
-			['Pandemonium Citadel', 5.42, 8.13, 10.84],
-			['Ashen Plains', 4.68, 7.02, 9.36],
-			['Sanatorium', 4.68, 7.02, 9.36],
-			['Kehjistan Marketplace', 4.39, 6.58, 8.77],
-			['Throne of Insanity', 4.00, 6.00, 8.00],
-			['Phlegethon', 3.98, 5.97, 7.96],
-			['Canyon of Sescheron', 3.70, 5.55, 7.40],
-			['Ruined Cistern', 3.50, 5.25, 7.01],
-			['Blood Moon', 2.89, 4.34, 5.78]
-		]},
-		{ tier: 2, maps: [
-			['Demon Road', 2.56, 3.84, 5.12],
-			['Ancestral Trial', 2.15, 3.23, 4.31],
-			['Lost Temple', 2.09, 3.13, 4.17],
-			['River of Blood', 2.04, 3.06, 4.08],
-			['Ruins of Viz-Jun', 1.91, 2.86, 3.81],
-			['Bastion Keep', 1.88, 2.83, 3.77],
-			['Tomb of Zoltun Kulle', 1.81, 2.71, 3.62],
-			['Skovos Stronghold', 0.94, 1.41, 1.88]
-		]},
-		{ tier: 1, maps: [
-			['Halls of Torture', 2.24, 3.36, 4.48],
-			['Sewers of Harrogath', 1.91, 2.86, 3.81],
-			['Arreat Battlefield', 1.85, 2.78, 3.71],
-			['Fall of Caldeum', 1.62, 2.43, 3.24],
-			['Royal Crypts', 1.62, 2.42, 3.23],
-			['Torajan Jungle', 1.60, 2.40, 3.19],
-			["Horazon's Memory", 1.47, 2.20, 2.94],
-			['Shadows of Westmarch', 1.36, 2.04, 2.72]
-		]}
-	];
+	var helpers = window.mapsDataHelpers;
+	var currentSeason = 'S13';
 
-	var dataNoneS12 = [
-		{ tier: 3, maps: [
-			['Pandemonium Citadel', 4.92, 7.38, 9.84],
-			['Ashen Plains', 4.92, 7.38, 9.84],
-			['Phlegethon', 4.50, 6.76, 9.01],
-			['Kehjistan Marketplace', 4.42, 6.62, 8.83],
-			['Sanatorium', 4.41, 6.62, 8.82],
-			['Canyon of Sescheron', 4.19, 6.29, 8.38],
-			['Throne of Insanity', 4.00, 6.00, 8.00],
-			['Ruined Cistern', 3.61, 5.41, 7.22],
-			['Blood Moon', 3.46, 5.19, 6.92]
-		]},
-		{ tier: 2, maps: [
-			['Ancestral Trial', 4.05, 6.07, 8.10],
-			['Demon Road', 4.03, 6.05, 8.07],
-			['Ruins of Viz-Jun', 4.01, 6.01, 8.01],
-			['Lost Temple', 3.73, 5.59, 7.46],
-			['River of Blood', 3.72, 5.58, 7.43],
-			['Skovos Stronghold', 3.67, 5.50, 7.33],
-			['Bastion Keep', 3.65, 5.47, 7.30],
-			['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57]
-		]},
-		{ tier: 1, maps: [
-			['Halls of Torture', 5.32, 7.98, 10.64],
-			['Torajan Jungle', 4.73, 7.09, 9.46],
-			['Arreat Battlefield', 4.23, 6.34, 8.46],
-			["Horazon's Memory", 4.10, 6.14, 8.19],
-			['Sewers of Harrogath', 3.94, 5.90, 7.87],
-			['Royal Crypts', 3.58, 5.37, 7.16],
-			['Fall of Caldeum', 3.51, 5.26, 7.02],
-			['Shadows of Westmarch', 3.17, 4.75, 6.33]
-		]}
-	];
+	function loadData98() {
+		return currentSeason === 'S12'
+			? window.mapsData.s12.exp98
+			: helpers.buildS13Exp('exp98');
+	}
+	function loadDataNone() {
+		return currentSeason === 'S12'
+			? window.mapsData.s12.expNone
+			: helpers.buildS13Exp('expNone');
+	}
 
-	// ===== Season 13 (current) =====
-	var data98S13 = [
-		{ tier: 3, maps: [
-			['Kehjistan Marketplace', 4.39, 6.58, 8.77],
-			['Arreat Battlefield', 4.13, 6.19, 8.25],
-			['Demon Road', 4.01, 6.01, 8.01],
-			['Royal Crypts', 3.56, 5.33, 7.11],
-			['River of Blood', 3.37, 5.06, 6.75],
-			['Bastion Keep', 3.20, 4.79, 6.39],
-			['Blood Moon', 2.89, 4.34, 5.78],
-			['Skovos Stronghold', 'TBD', 'TBD', 'TBD'],
-			['Kyovoshad', 'TBD', 'TBD', 'TBD']
-		]},
-		{ tier: 2, maps: [
-			['Pandemonium Citadel', 3.65, 5.48, 7.30],
-			['Halls of Torture', 3.16, 4.74, 6.32],
-			['Sanatorium', 3.09, 4.64, 6.18],
-			['Ashen Plains', 2.91, 4.37, 5.82],
-			['Sewers of Harrogath', 2.70, 4.04, 5.39],
-			['Throne of Insanity', 2.56, 3.84, 5.13],
-			['Ruined Cistern', 2.27, 3.41, 4.54],
-			['Canyon of Sescheron', 2.20, 3.29, 4.39],
-			["Horazon's Memory", 2.04, 3.05, 4.07]
-		]},
-		{ tier: 1, maps: [
-			['Phlegethon', 1.71, 2.56, 3.42],
-			['Fall of Caldeum', 1.62, 2.43, 3.24],
-			['Torajan Jungle', 1.60, 2.40, 3.19],
-			['Ancestral Trial', 1.54, 2.31, 3.08],
-			['Lost Temple', 1.49, 2.24, 2.98],
-			['Ruins of Viz-Jun', 1.37, 2.06, 2.74],
-			['Shadows of Westmarch', 1.36, 2.04, 2.72],
-			['Tomb of Zoltun Kulle', 1.29, 1.94, 2.59]
-		]}
-	];
-
-	var dataNoneS13 = [
-		{ tier: 3, maps: [
-			['Kehjistan Marketplace', 4.42, 6.62, 8.83],
-			['Arreat Battlefield', 4.23, 6.34, 8.46],
-			['Demon Road', 4.03, 6.05, 8.07],
-			['River of Blood', 3.72, 5.58, 7.43],
-			['Bastion Keep', 3.65, 5.47, 7.30],
-			['Royal Crypts', 3.58, 5.37, 7.16],
-			['Blood Moon', 3.46, 5.19, 6.92],
-			['Skovos Stronghold', 'TBD', 'TBD', 'TBD'],
-			['Kyovoshad', 'TBD', 'TBD', 'TBD']
-		]},
-		{ tier: 2, maps: [
-			['Halls of Torture', 5.32, 7.98, 10.64],
-			['Pandemonium Citadel', 4.92, 7.38, 9.84],
-			['Ashen Plains', 4.92, 7.38, 9.84],
-			['Sanatorium', 4.41, 6.62, 8.82],
-			['Canyon of Sescheron', 4.19, 6.29, 8.38],
-			["Horazon's Memory", 4.10, 6.14, 8.19],
-			['Throne of Insanity', 4.00, 6.00, 8.00],
-			['Sewers of Harrogath', 3.94, 5.90, 7.87],
-			['Ruined Cistern', 3.61, 5.41, 7.22]
-		]},
-		{ tier: 1, maps: [
-			['Torajan Jungle', 4.73, 7.09, 9.46],
-			['Phlegethon', 4.50, 6.76, 9.01],
-			['Ancestral Trial', 4.05, 6.07, 8.10],
-			['Ruins of Viz-Jun', 4.01, 6.01, 8.01],
-			['Lost Temple', 3.73, 5.59, 7.46],
-			['Fall of Caldeum', 3.51, 5.26, 7.02],
-			['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57],
-			['Shadows of Westmarch', 3.17, 4.75, 6.33]
-		]}
-	];
-
-	var data98 = data98S13, dataNone = dataNoneS13;
+	var data98 = loadData98(), dataNone = loadDataNone();
 
 	function fmt(v) {
 		var totalSec = Math.round(v * 60);
@@ -1719,34 +1594,7 @@ function fallbackDownloadWheelImage(blob, statusEl) {
 		return m + ':' + (s < 10 ? '0' : '') + s;
 	}
 
-	var mapElems = {
-		'Canyon of Sescheron': [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}],
-		'Phlegethon': [{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}],
-		'Blood Moon': [],
-		'Ashen Plains': [{i:2,v:'120',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}],
-		'Kehjistan Marketplace': [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}],
-		'Throne of Insanity': [{i:0,v:'115',c:'160,160,160'},{i:5,v:'120',c:'80,200,80'}],
-		'Sanatorium': [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}],
-		'Ruined Cistern': [{i:1,v:'105',c:'180,80,220'},{i:5,v:'120',c:'80,200,80'}],
-		'Pandemonium Citadel': [{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}],
-		'Ruins of Viz-Jun': [{i:0,v:'115',c:'160,160,160'},{i:4,v:'120',c:'60,140,220'}],
-		'Ancestral Trial': [{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}],
-		'Tomb of Zoltun Kulle': [{i:0,v:'115',c:'160,160,160'},{i:5,v:'120',c:'80,200,80'}],
-		'Bastion Keep': [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}],
-		'River of Blood': [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}],
-		'Demon Road': [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}],
-		'Skovos Stronghold': [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}],
-		'Kyovoshad': [],
-		'Lost Temple': [{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}],
-		'Torajan Jungle': [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}],
-		'Halls of Torture': [{i:3,v:'120',c:'220,200,40'},{i:4,v:'120',c:'60,140,220'}],
-		"Horazon's Memory": [{i:0,v:'115',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'}],
-		'Arreat Battlefield': [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}],
-		'Royal Crypts': [{i:2,v:'120',c:'220,60,40'},{i:4,v:'120',c:'60,140,220'}],
-		'Sewers of Harrogath': [{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}],
-		'Shadows of Westmarch': [{i:1,v:'105',c:'180,80,220'},{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}],
-		'Fall of Caldeum': [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'}]
-	};
+	var mapElems = helpers.getS13Elems();
 
 	function elemCells(name) {
 		var elems = mapElems[name] || [];
@@ -1844,11 +1692,9 @@ function fallbackDownloadWheelImage(blob, statusEl) {
 	// Season toggle
 	document.querySelectorAll('input[name="groupSeason"]').forEach(function(radio) {
 		radio.addEventListener('change', function() {
-			if (this.value === 'S12') {
-				data98 = data98S12; dataNone = dataNoneS12;
-			} else {
-				data98 = data98S13; dataNone = dataNoneS13;
-			}
+			currentSeason = this.value;
+			data98 = loadData98();
+			dataNone = loadDataNone();
 			calcMapName = null; calcTimeSec = 0;
 			document.getElementById('groupCalcMapSelect').value = '';
 			document.getElementById('groupCalcMin').value = '';

--- a/maps-data.js
+++ b/maps-data.js
@@ -1,0 +1,298 @@
+// Shared maps data — used by solo.html, maps.html, group.html
+// Time values are decimal minutes (e.g. 4.39 = 4 min 23.4s). Consumers round to nearest 5s.
+// `mfFullClear` = default Solo MF (full clear). `mfEliteSkip` = alternative Solo MF (elite skip).
+window.mapsData = {
+	season: 13,
+
+	// ===== Season 13 (current) =====
+	s13: [
+		// Tier 3
+		{ name: 'Kehjistan Marketplace', slug: 'marketplace', tier: 3,
+			exp98: [4.39, 6.58, 8.77], expNone: [4.42, 6.62, 8.83],
+			mfEliteSkip: [4.30, 6.46, 8.61], mfFullClear: [4.95, 7.42, 9.90],
+			itemDropCount: 1367,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}] },
+		{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', tier: 3,
+			exp98: [4.13, 6.19, 8.25], expNone: [4.23, 6.34, 8.46],
+			mfEliteSkip: [4.03, 6.05, 8.07], mfFullClear: [4.63, 6.95, 9.27],
+			itemDropCount: 1280,
+			elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Demon Road', slug: 'demonroad', tier: 3,
+			exp98: [4.01, 6.01, 8.01], expNone: [4.03, 6.05, 8.07],
+			mfEliteSkip: [3.81, 5.71, 7.62], mfFullClear: [4.44, 6.66, 8.88],
+			itemDropCount: 1226,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
+		{ name: 'Royal Crypts', slug: 'royalcrypts', tier: 3,
+			exp98: [3.56, 5.33, 7.11], expNone: [3.58, 5.37, 7.16],
+			mfEliteSkip: [3.80, 5.71, 7.61], mfFullClear: [4.36, 6.54, 8.72],
+			itemDropCount: 1205,
+			elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'120',c:'60,140,220'}] },
+		{ name: 'River of Blood', slug: 'riverblood', tier: 3,
+			exp98: [3.37, 5.06, 6.75], expNone: [3.72, 5.58, 7.43],
+			mfEliteSkip: [3.96, 5.94, 7.92], mfFullClear: [4.55, 6.83, 9.11],
+			itemDropCount: 1258,
+			elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Bastion Keep', slug: 'bastion', tier: 3,
+			exp98: [3.20, 4.79, 6.39], expNone: [3.65, 5.47, 7.30],
+			mfEliteSkip: [4.05, 6.08, 8.11], mfFullClear: [4.61, 6.92, 9.22],
+			itemDropCount: 1274,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
+		{ name: 'Blood Moon', slug: 'bloodmoon', tier: 3,
+			exp98: [2.89, 4.34, 5.78], expNone: [3.46, 5.19, 6.92],
+			mfEliteSkip: [5.29, 7.93, 10.58], mfFullClear: [5.77, 8.65, 11.53],
+			itemDropCount: 1593,
+			elems: [] },
+		{ name: 'Skovos Stronghold', slug: 'skovos', tier: 3,
+			exp98: null, expNone: null,
+			mfEliteSkip: null, mfFullClear: null,
+			itemDropCount: null,
+			elems: [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Kyovoshad', slug: 'kyovoshad', tier: 3,
+			exp98: null, expNone: null,
+			mfEliteSkip: null, mfFullClear: null,
+			itemDropCount: null,
+			elems: [] },
+
+		// Tier 2
+		{ name: 'Pandemonium Citadel', slug: 'citadel', tier: 2,
+			exp98: [3.65, 5.48, 7.30], expNone: [4.92, 7.38, 9.84],
+			mfEliteSkip: [2.52, 3.78, 5.04], mfFullClear: [3.01, 4.51, 6.01],
+			itemDropCount: 977,
+			elems: [{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
+		{ name: 'Halls of Torture', slug: 'hallsoftorture', tier: 2,
+			exp98: [3.16, 4.74, 6.32], expNone: [5.32, 7.98, 10.64],
+			mfEliteSkip: [4.05, 6.07, 8.10], mfFullClear: [4.59, 6.89, 9.18],
+			itemDropCount: 1492,
+			elems: [{i:3,v:'120',c:'220,200,40'},{i:4,v:'120',c:'60,140,220'}] },
+		{ name: 'Sanatorium', slug: 'sanatorium', tier: 2,
+			exp98: [3.09, 4.64, 6.18], expNone: [4.41, 6.62, 8.82],
+			mfEliteSkip: [2.94, 4.41, 5.88], mfFullClear: [3.52, 5.28, 7.03],
+			itemDropCount: 1143,
+			elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Ashen Plains', slug: 'ashen', tier: 2,
+			exp98: [2.91, 4.37, 5.82], expNone: [4.92, 7.38, 9.84],
+			mfEliteSkip: [3.80, 5.70, 7.59], mfFullClear: [4.28, 6.42, 8.55],
+			itemDropCount: 1390,
+			elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+		{ name: 'Sewers of Harrogath', slug: 'sewers', tier: 2,
+			exp98: [2.70, 4.04, 5.39], expNone: [3.94, 5.90, 7.87],
+			mfEliteSkip: [3.10, 4.65, 6.20], mfFullClear: [3.62, 5.42, 7.23],
+			itemDropCount: 1175,
+			elems: [{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Throne of Insanity', slug: 'throne', tier: 2,
+			exp98: [2.56, 3.84, 5.13], expNone: [4.00, 6.00, 8.00],
+			mfEliteSkip: [3.40, 5.10, 6.80], mfFullClear: [3.89, 5.83, 7.77],
+			itemDropCount: 1263,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Ruined Cistern', slug: 'cistern', tier: 2,
+			exp98: [2.27, 3.41, 4.54], expNone: [3.61, 5.41, 7.22],
+			mfEliteSkip: [2.67, 4.01, 5.34], mfFullClear: [3.19, 4.79, 6.39],
+			itemDropCount: 1038,
+			elems: [{i:1,v:'105',c:'180,80,220'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Canyon of Sescheron', slug: 'canyon', tier: 2,
+			exp98: [2.20, 3.29, 4.39], expNone: [4.19, 6.29, 8.38],
+			mfEliteSkip: [4.86, 7.30, 9.73], mfFullClear: [5.37, 8.05, 10.74],
+			itemDropCount: 1745,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}] },
+		{ name: "Horazon's Memory", slug: 'horazonsmemory', tier: 2,
+			exp98: [2.04, 3.05, 4.07], expNone: [4.10, 6.14, 8.19],
+			mfEliteSkip: [3.87, 5.81, 7.75], mfFullClear: [4.33, 6.49, 8.66],
+			itemDropCount: 1407,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'}] },
+
+		// Tier 1
+		{ name: 'Phlegethon', slug: 'phlegethon', tier: 1,
+			exp98: [1.71, 2.56, 3.42], expNone: [4.50, 6.76, 9.01],
+			mfEliteSkip: [4.55, 6.82, 9.10], mfFullClear: [5.11, 7.67, 10.23],
+			itemDropCount: 1662,
+			elems: [{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Fall of Caldeum', slug: 'caldeum', tier: 1,
+			exp98: [1.62, 2.43, 3.24], expNone: [3.51, 5.26, 7.02],
+			mfEliteSkip: [2.43, 3.65, 4.86], mfFullClear: [2.86, 4.28, 5.71],
+			itemDropCount: 928,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'}] },
+		{ name: 'Torajan Jungle', slug: 'torajanjungle', tier: 1,
+			exp98: [1.60, 2.40, 3.19], expNone: [4.73, 7.09, 9.46],
+			mfEliteSkip: [4.48, 6.72, 8.95], mfFullClear: [4.99, 7.49, 9.99],
+			itemDropCount: 1623,
+			elems: [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Ancestral Trial', slug: 'ancestral', tier: 1,
+			exp98: [1.54, 2.31, 3.08], expNone: [4.05, 6.07, 8.10],
+			mfEliteSkip: [3.91, 5.87, 7.82], mfFullClear: [4.45, 6.67, 8.89],
+			itemDropCount: 1445,
+			elems: [{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
+		{ name: 'Lost Temple', slug: 'losttemple', tier: 1,
+			exp98: [1.49, 2.24, 2.98], expNone: [3.73, 5.59, 7.46],
+			mfEliteSkip: [2.70, 4.05, 5.40], mfFullClear: [3.04, 4.56, 6.09],
+			itemDropCount: 989,
+			elems: [{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
+		{ name: 'Ruins of Viz-Jun', slug: 'ruinsofvizjun', tier: 1,
+			exp98: [1.37, 2.06, 2.74], expNone: [4.01, 6.01, 8.01],
+			mfEliteSkip: [4.03, 6.05, 8.07], mfFullClear: [4.56, 6.84, 9.13],
+			itemDropCount: 1483,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:4,v:'120',c:'60,140,220'}] },
+		{ name: 'Shadows of Westmarch', slug: 'westmarch', tier: 1,
+			exp98: [1.36, 2.04, 2.72], expNone: [3.17, 4.75, 6.33],
+			mfEliteSkip: [2.97, 4.45, 5.93], mfFullClear: [3.46, 5.20, 6.93],
+			itemDropCount: 1126,
+			elems: [{i:1,v:'105',c:'180,80,220'},{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
+		{ name: 'Tomb of Zoltun Kulle', slug: 'zoltun', tier: 1,
+			exp98: [1.29, 1.94, 2.59], expNone: [3.29, 4.93, 6.57],
+			mfEliteSkip: [3.85, 5.78, 7.70], mfFullClear: [4.38, 6.56, 8.75],
+			itemDropCount: 1422,
+			elems: [{i:0,v:'115',c:'160,160,160'},{i:5,v:'120',c:'80,200,80'}] }
+	],
+
+	// ===== Season 12 (archive) =====
+	// S12 had a single Solo/MF time variant (no Elite Skip / Full Clear split).
+	s12: {
+		mfData: [
+			{ tier: 3, maps: [
+				{ name: 'Canyon of Sescheron', slug: 'canyon', top: '5:45', good: '8:35', decent: '11:25', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
+				{ name: 'Phlegethon', slug: 'phlegethon', top: '5:20', good: '8:00', decent: '10:40', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
+				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
+				{ name: 'Ashen Plains', slug: 'ashen', top: '4:30', good: '6:40', decent: '8:55', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Kehjistan Marketplace', slug: 'marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+				{ name: 'Throne of Insanity', slug: 'throne', top: '4:00', good: '6:00', decent: '8:00', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'Sanatorium', slug: 'sanatorium', top: '3:30', good: '5:10', decent: '6:55', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Ruined Cistern', slug: 'cistern', top: '3:10', good: '4:45', decent: '6:15', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
+				{ name: 'Pandemonium Citadel', slug: 'citadel', top: '3:00', good: '4:25', decent: '5:55', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
+			]},
+			{ tier: 2, maps: [
+				{ name: 'Ruins of Viz-Jun', slug: 'ruinsofvizjun', top: '3:30', good: '5:15', decent: '7:00', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
+				{ name: 'Ancestral Trial', slug: 'ancestral', top: '3:25', good: '5:05', decent: '6:50', elems: [{i:5,v:'120',c:'80,200,80'}] },
+				{ name: 'Tomb of Zoltun Kulle', slug: 'zoltun', top: '3:20', good: '5:00', decent: '6:45', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
+				{ name: 'Bastion Keep', slug: 'bastion', top: '3:00', good: '4:30', decent: '6:00', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'River of Blood', slug: 'riverblood', top: '2:55', good: '4:25', decent: '5:50', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
+				{ name: 'Demon Road', slug: 'demonroad', top: '2:50', good: '4:15', decent: '5:40', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
+				{ name: 'Skovos Stronghold', slug: 'skovos', top: '2:25', good: '3:40', decent: '4:50', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] },
+				{ name: 'Lost Temple', slug: 'losttemple', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] }
+			]},
+			{ tier: 1, maps: [
+				{ name: 'Torajan Jungle', slug: 'torajanjungle', top: '4:00', good: '6:00', decent: '7:55', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
+				{ name: 'Halls of Torture', slug: 'hallsoftorture', top: '3:35', good: '5:25', decent: '7:10', elems: [] },
+				{ name: "Horazon's Memory", slug: 'horazonsmemory', top: '3:25', good: '5:10', decent: '6:55', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
+				{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', top: '3:00', good: '4:35', decent: '6:05', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
+				{ name: 'Royal Crypts', slug: 'royalcrypts', top: '2:50', good: '4:20', decent: '5:45', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
+				{ name: 'Sewers of Harrogath', slug: 'sewers', top: '2:45', good: '4:10', decent: '5:30', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
+				{ name: 'Shadows of Westmarch', slug: 'westmarch', top: '2:40', good: '3:55', decent: '5:15', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
+				{ name: 'Fall of Caldeum', slug: 'caldeum', top: '2:10', good: '3:15', decent: '4:20', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
+			]}
+		],
+		exp98: [
+			{ tier: 3, maps: [
+				['Pandemonium Citadel', 5.42, 8.13, 10.84], ['Ashen Plains', 4.68, 7.02, 9.36],
+				['Sanatorium', 4.68, 7.02, 9.36], ['Kehjistan Marketplace', 4.39, 6.58, 8.77],
+				['Throne of Insanity', 4.00, 6.00, 8.00], ['Phlegethon', 3.98, 5.97, 7.96],
+				['Canyon of Sescheron', 3.70, 5.55, 7.40], ['Ruined Cistern', 3.50, 5.25, 7.01],
+				['Blood Moon', 2.89, 4.34, 5.78]
+			]},
+			{ tier: 2, maps: [
+				['Demon Road', 2.56, 3.84, 5.12], ['Ancestral Trial', 2.15, 3.23, 4.31],
+				['Lost Temple', 2.09, 3.13, 4.17], ['River of Blood', 2.04, 3.06, 4.08],
+				['Ruins of Viz-Jun', 1.91, 2.86, 3.81], ['Bastion Keep', 1.88, 2.83, 3.77],
+				['Tomb of Zoltun Kulle', 1.81, 2.71, 3.62], ['Skovos Stronghold', 0.94, 1.41, 1.88]
+			]},
+			{ tier: 1, maps: [
+				['Halls of Torture', 2.24, 3.36, 4.48], ['Sewers of Harrogath', 1.91, 2.86, 3.81],
+				['Arreat Battlefield', 1.85, 2.78, 3.71], ['Fall of Caldeum', 1.62, 2.43, 3.24],
+				['Royal Crypts', 1.62, 2.42, 3.23], ['Torajan Jungle', 1.60, 2.40, 3.19],
+				["Horazon's Memory", 1.47, 2.20, 2.94], ['Shadows of Westmarch', 1.36, 2.04, 2.72]
+			]}
+		],
+		expNone: [
+			{ tier: 3, maps: [
+				['Pandemonium Citadel', 4.92, 7.38, 9.84], ['Ashen Plains', 4.92, 7.38, 9.84],
+				['Phlegethon', 4.50, 6.76, 9.01], ['Kehjistan Marketplace', 4.42, 6.62, 8.83],
+				['Sanatorium', 4.41, 6.62, 8.82], ['Canyon of Sescheron', 4.19, 6.29, 8.38],
+				['Throne of Insanity', 4.00, 6.00, 8.00], ['Ruined Cistern', 3.61, 5.41, 7.22],
+				['Blood Moon', 3.46, 5.19, 6.92]
+			]},
+			{ tier: 2, maps: [
+				['Ancestral Trial', 4.05, 6.07, 8.10], ['Demon Road', 4.03, 6.05, 8.07],
+				['Ruins of Viz-Jun', 4.01, 6.01, 8.01], ['Lost Temple', 3.73, 5.59, 7.46],
+				['River of Blood', 3.72, 5.58, 7.43], ['Skovos Stronghold', 3.67, 5.50, 7.33],
+				['Bastion Keep', 3.65, 5.47, 7.30], ['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57]
+			]},
+			{ tier: 1, maps: [
+				['Halls of Torture', 5.32, 7.98, 10.64], ['Torajan Jungle', 4.73, 7.09, 9.46],
+				['Arreat Battlefield', 4.23, 6.34, 8.46], ["Horazon's Memory", 4.10, 6.14, 8.19],
+				['Sewers of Harrogath', 3.94, 5.90, 7.87], ['Royal Crypts', 3.58, 5.37, 7.16],
+				['Fall of Caldeum', 3.51, 5.26, 7.02], ['Shadows of Westmarch', 3.17, 4.75, 6.33]
+			]}
+		]
+	}
+};
+
+// Helpers used by all 3 consumer pages
+window.mapsDataHelpers = {
+	// Round decimal-minute value to nearest 5s and format as M:SS. Returns 'TBD' if null.
+	fmtMin: function (v) {
+		if (v == null) return 'TBD';
+		var totalSec = Math.round(Math.round(v * 60) / 5) * 5;
+		var m = Math.floor(totalSec / 60);
+		var s = totalSec % 60;
+		return m + ':' + (s < 10 ? '0' : '') + s;
+	},
+
+	// Build tier-grouped Solo/MF dataset for S13 in `{tier, maps:[{name,slug,top,good,decent,elems}]}` shape.
+	// `variant` is 'fullClear' (default) or 'eliteSkip'.
+	buildS13MfData: function (variant) {
+		var fmt = this.fmtMin;
+		var field = variant === 'eliteSkip' ? 'mfEliteSkip' : 'mfFullClear';
+		var byTier = { 3: [], 2: [], 1: [] };
+		window.mapsData.s13.forEach(function (m) {
+			var arr = m[field];
+			byTier[m.tier].push({
+				name: m.name, slug: m.slug, elems: m.elems,
+				top: fmt(arr ? arr[0] : null),
+				good: fmt(arr ? arr[1] : null),
+				decent: fmt(arr ? arr[2] : null),
+				_topMin: arr ? arr[0] : null
+			});
+		});
+		[3, 2, 1].forEach(function (t) {
+			byTier[t].sort(function (a, b) {
+				if (a._topMin == null) return 1;
+				if (b._topMin == null) return -1;
+				return b._topMin - a._topMin;
+			});
+		});
+		return [
+			{ tier: 3, maps: byTier[3] },
+			{ tier: 2, maps: byTier[2] },
+			{ tier: 1, maps: byTier[1] }
+		];
+	},
+
+	// Build tier-grouped EXP dataset for S13 in `{tier, maps:[[name,top,good,decent]]}` shape.
+	// `variant` is 'exp98' or 'expNone'.
+	buildS13Exp: function (variant) {
+		var byTier = { 3: [], 2: [], 1: [] };
+		window.mapsData.s13.forEach(function (m) {
+			var arr = m[variant];
+			byTier[m.tier].push(arr
+				? [m.name, arr[0], arr[1], arr[2]]
+				: [m.name, 'TBD', 'TBD', 'TBD']);
+		});
+		[3, 2, 1].forEach(function (t) {
+			byTier[t].sort(function (a, b) {
+				if (a[1] === 'TBD') return 1;
+				if (b[1] === 'TBD') return -1;
+				return b[1] - a[1];
+			});
+		});
+		return [
+			{ tier: 3, maps: byTier[3] },
+			{ tier: 2, maps: byTier[2] },
+			{ tier: 1, maps: byTier[1] }
+		];
+	},
+
+	// Element-resistance lookup keyed by map name (S13).
+	getS13Elems: function () {
+		var out = {};
+		window.mapsData.s13.forEach(function (m) { out[m.name] = m.elems; });
+		return out;
+	}
+};

--- a/maps.html
+++ b/maps.html
@@ -1566,13 +1566,20 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 					<label class="btn btn-outline-info" for="mapTimesS12">Season 12</label>
 				</div>
 				<br>
-				<div class="btn-group btn-group-sm mb-3" role="group">
+				<div class="btn-group btn-group-sm mb-2" role="group">
 					<input type="radio" class="btn-check" name="mapTimesMode" id="mapTimesMF" value="mf" checked>
 					<label class="btn btn-outline-light" for="mapTimesMF">Magic Find (monsters/hour)</label>
 					<input type="radio" class="btn-check" name="mapTimesMode" id="mapTimesExp98" value="exp98">
 					<label class="btn btn-outline-light" for="mapTimesExp98">Exp/hour (Lvl 98)</label>
 					<input type="radio" class="btn-check" name="mapTimesMode" id="mapTimesExpNone" value="expNone">
 					<label class="btn btn-outline-light" for="mapTimesExpNone">Exp/hour (No Penalty)</label>
+				</div>
+				<br>
+				<div class="btn-group btn-group-sm mb-3" id="mapTimesSoloTypeGroup" role="group" aria-label="Solo Type">
+					<input type="radio" class="btn-check" name="mapTimesSoloType" id="mapTimesSoloTypeFull" value="fullClear" checked>
+					<label class="btn btn-outline-light" for="mapTimesSoloTypeFull">MF Full Clear</label>
+					<input type="radio" class="btn-check" name="mapTimesSoloType" id="mapTimesSoloTypeElite" value="eliteSkip">
+					<label class="btn btn-outline-light" for="mapTimesSoloTypeElite">MF Elite Skip</label>
 				</div>
 				<div id="mapTimesDesc"></div>
 				<div class="card bg-secondary bg-opacity-25 p-3 mb-3">
@@ -1609,6 +1616,7 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 	</div>
 </div>
 
+<script src="maps-data.js"></script>
 <script>
 (function () {
 	var mapSlugs = {
@@ -1625,173 +1633,30 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 		'Shadows of Westmarch': 'westmarch', 'Fall of Caldeum': 'caldeum'
 	};
 
-	// ===== Season 12 archive (clear speed + resistances) =====
-	var mfDataS12 = [
-		{ tier: 3, maps: [
-			{ name: 'Canyon of Sescheron', top: '5:45', good: '8:35', decent: '11:25', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
-			{ name: 'Phlegethon', top: '5:20', good: '8:00', decent: '10:40', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
-			{ name: 'Blood Moon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
-			{ name: 'Ashen Plains', top: '4:30', good: '6:40', decent: '8:55', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Kehjistan Marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-			{ name: 'Throne of Insanity', top: '4:00', good: '6:00', decent: '8:00', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Sanatorium', top: '3:30', good: '5:10', decent: '6:55', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Ruined Cistern', top: '3:10', good: '4:45', decent: '6:15', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
-			{ name: 'Pandemonium Citadel', top: '3:00', good: '4:25', decent: '5:55', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
-		]},
-		{ tier: 2, maps: [
-			{ name: 'Ruins of Viz-Jun', top: '3:30', good: '5:15', decent: '7:00', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-			{ name: 'Ancestral Trial', top: '3:25', good: '5:05', decent: '6:50', elems: [{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Tomb of Zoltun Kulle', top: '3:20', good: '5:00', decent: '6:45', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
-			{ name: 'Bastion Keep', top: '3:00', good: '4:30', decent: '6:00', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'River of Blood', top: '2:55', good: '4:25', decent: '5:50', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-			{ name: 'Demon Road', top: '2:50', good: '4:15', decent: '5:40', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
-			{ name: 'Skovos Stronghold', top: '2:25', good: '3:40', decent: '4:50', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] },
-			{ name: 'Lost Temple', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] }
-		]},
-		{ tier: 1, maps: [
-			{ name: 'Torajan Jungle', top: '4:00', good: '6:00', decent: '7:55', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
-			{ name: 'Halls of Torture', top: '3:35', good: '5:25', decent: '7:10', elems: [] },
-			{ name: "Horazon's Memory", top: '3:25', good: '5:10', decent: '6:55', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Arreat Battlefield', top: '3:00', good: '4:35', decent: '6:05', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
-			{ name: 'Royal Crypts', top: '2:50', good: '4:20', decent: '5:45', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-			{ name: 'Sewers of Harrogath', top: '2:45', good: '4:10', decent: '5:30', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
-			{ name: 'Shadows of Westmarch', top: '2:40', good: '3:55', decent: '5:15', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
-			{ name: 'Fall of Caldeum', top: '2:10', good: '3:15', decent: '4:20', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
-		]}
-	];
+	var helpers = window.mapsDataHelpers;
+	var currentSeason = 'S13';
+	var currentSoloType = 'fullClear';
 
-	var exp98S12 = [
-		{ tier: 3, maps: [
-			['Pandemonium Citadel', 5.42, 8.13, 10.84], ['Ashen Plains', 4.68, 7.02, 9.36],
-			['Sanatorium', 4.68, 7.02, 9.36], ['Kehjistan Marketplace', 4.39, 6.58, 8.77],
-			['Throne of Insanity', 4.00, 6.00, 8.00], ['Phlegethon', 3.98, 5.97, 7.96],
-			['Canyon of Sescheron', 3.70, 5.55, 7.40], ['Ruined Cistern', 3.50, 5.25, 7.01],
-			['Blood Moon', 2.89, 4.34, 5.78]
-		]},
-		{ tier: 2, maps: [
-			['Demon Road', 2.56, 3.84, 5.12], ['Ancestral Trial', 2.15, 3.23, 4.31],
-			['Lost Temple', 2.09, 3.13, 4.17], ['River of Blood', 2.04, 3.06, 4.08],
-			['Ruins of Viz-Jun', 1.91, 2.86, 3.81], ['Bastion Keep', 1.88, 2.83, 3.77],
-			['Tomb of Zoltun Kulle', 1.81, 2.71, 3.62], ['Skovos Stronghold', 0.94, 1.41, 1.88]
-		]},
-		{ tier: 1, maps: [
-			['Halls of Torture', 2.24, 3.36, 4.48], ['Sewers of Harrogath', 1.91, 2.86, 3.81],
-			['Arreat Battlefield', 1.85, 2.78, 3.71], ['Fall of Caldeum', 1.62, 2.43, 3.24],
-			['Royal Crypts', 1.62, 2.42, 3.23], ['Torajan Jungle', 1.60, 2.40, 3.19],
-			["Horazon's Memory", 1.47, 2.20, 2.94], ['Shadows of Westmarch', 1.36, 2.04, 2.72]
-		]}
-	];
+	function loadMfData() {
+		return currentSeason === 'S12'
+			? window.mapsData.s12.mfData
+			: helpers.buildS13MfData(currentSoloType);
+	}
+	function loadExp98() {
+		return currentSeason === 'S12'
+			? window.mapsData.s12.exp98
+			: helpers.buildS13Exp('exp98');
+	}
+	function loadExpNone() {
+		return currentSeason === 'S12'
+			? window.mapsData.s12.expNone
+			: helpers.buildS13Exp('expNone');
+	}
 
-	var expNoneS12 = [
-		{ tier: 3, maps: [
-			['Pandemonium Citadel', 4.92, 7.38, 9.84], ['Ashen Plains', 4.92, 7.38, 9.84],
-			['Phlegethon', 4.50, 6.76, 9.01], ['Kehjistan Marketplace', 4.42, 6.62, 8.83],
-			['Sanatorium', 4.41, 6.62, 8.82], ['Canyon of Sescheron', 4.19, 6.29, 8.38],
-			['Throne of Insanity', 4.00, 6.00, 8.00], ['Ruined Cistern', 3.61, 5.41, 7.22],
-			['Blood Moon', 3.46, 5.19, 6.92]
-		]},
-		{ tier: 2, maps: [
-			['Ancestral Trial', 4.05, 6.07, 8.10], ['Demon Road', 4.03, 6.05, 8.07],
-			['Ruins of Viz-Jun', 4.01, 6.01, 8.01], ['Lost Temple', 3.73, 5.59, 7.46],
-			['River of Blood', 3.72, 5.58, 7.43], ['Skovos Stronghold', 3.67, 5.50, 7.33],
-			['Bastion Keep', 3.65, 5.47, 7.30], ['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57]
-		]},
-		{ tier: 1, maps: [
-			['Halls of Torture', 5.32, 7.98, 10.64], ['Torajan Jungle', 4.73, 7.09, 9.46],
-			['Arreat Battlefield', 4.23, 6.34, 8.46], ["Horazon's Memory", 4.10, 6.14, 8.19],
-			['Sewers of Harrogath', 3.94, 5.90, 7.87], ['Royal Crypts', 3.58, 5.37, 7.16],
-			['Fall of Caldeum', 3.51, 5.26, 7.02], ['Shadows of Westmarch', 3.17, 4.75, 6.33]
-		]}
-	];
-
-	// ===== Season 13 (current) =====
-	var mfDataS13 = [
-		{ tier: 3, maps: [
-			{ name: 'Blood Moon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
-			{ name: 'Kehjistan Marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}] },
-			{ name: 'Bastion Keep', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
-			{ name: 'Arreat Battlefield', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'River of Blood', top: '4:00', good: '5:55', decent: '7:55', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Demon Road', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-			{ name: 'Royal Crypts', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'120',c:'60,140,220'}] },
-			{ name: 'Skovos Stronghold', top: 'TBD', good: 'TBD', decent: 'TBD', elems: [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Kyovoshad', top: 'TBD', good: 'TBD', decent: 'TBD', elems: [] }
-		]},
-		{ tier: 2, maps: [
-			{ name: 'Canyon of Sescheron', top: '4:50', good: '7:20', decent: '9:45', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}] },
-			{ name: 'Halls of Torture', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:3,v:'120',c:'220,200,40'},{i:4,v:'120',c:'60,140,220'}] },
-			{ name: "Horazon's Memory", top: '3:50', good: '5:50', decent: '7:45', elems: [{i:0,v:'115',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'}] },
-			{ name: 'Ashen Plains', top: '3:50', good: '5:40', decent: '7:35', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-			{ name: 'Throne of Insanity', top: '3:25', good: '5:05', decent: '6:50', elems: [{i:0,v:'115',c:'160,160,160'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Sewers of Harrogath', top: '3:05', good: '4:40', decent: '6:10', elems: [{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Sanatorium', top: '2:55', good: '4:25', decent: '5:55', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Ruined Cistern', top: '2:40', good: '4:00', decent: '5:20', elems: [{i:1,v:'105',c:'180,80,220'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Pandemonium Citadel', top: '2:30', good: '3:45', decent: '5:00', elems: [{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] }
-		]},
-		{ tier: 1, maps: [
-			{ name: 'Phlegethon', top: '3:55', good: '5:55', decent: '7:55', elems: [{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Torajan Jungle', top: '3:55', good: '5:50', decent: '7:45', elems: [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Ruins of Viz-Jun', top: '3:30', good: '5:15', decent: '7:00', elems: [{i:0,v:'115',c:'160,160,160'},{i:4,v:'120',c:'60,140,220'}] },
-			{ name: 'Ancestral Trial', top: '3:25', good: '5:05', decent: '6:45', elems: [{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-			{ name: 'Tomb of Zoltun Kulle', top: '3:20', good: '5:00', decent: '6:40', elems: [{i:0,v:'115',c:'160,160,160'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Shadows of Westmarch', top: '2:35', good: '3:50', decent: '5:10', elems: [{i:1,v:'105',c:'180,80,220'},{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
-			{ name: 'Lost Temple', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
-			{ name: 'Fall of Caldeum', top: '2:05', good: '3:10', decent: '4:15', elems: [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'}] }
-		]}
-	];
-
-	var exp98S13 = [
-		{ tier: 3, maps: [
-			['Kehjistan Marketplace', 4.39, 6.58, 8.77], ['Arreat Battlefield', 4.13, 6.19, 8.25],
-			['Demon Road', 4.01, 6.01, 8.01], ['Royal Crypts', 3.56, 5.33, 7.11],
-			['River of Blood', 3.37, 5.06, 6.75], ['Bastion Keep', 3.20, 4.79, 6.39],
-			['Blood Moon', 2.89, 4.34, 5.78], ['Skovos Stronghold', 'TBD', 'TBD', 'TBD'],
-			['Kyovoshad', 'TBD', 'TBD', 'TBD']
-		]},
-		{ tier: 2, maps: [
-			['Pandemonium Citadel', 3.65, 5.48, 7.30], ['Halls of Torture', 3.16, 4.74, 6.32],
-			['Sanatorium', 3.09, 4.64, 6.18], ['Ashen Plains', 2.91, 4.37, 5.82],
-			['Sewers of Harrogath', 2.70, 4.04, 5.39], ['Throne of Insanity', 2.56, 3.84, 5.13],
-			['Ruined Cistern', 2.27, 3.41, 4.54], ['Canyon of Sescheron', 2.20, 3.29, 4.39],
-			["Horazon's Memory", 2.04, 3.05, 4.07]
-		]},
-		{ tier: 1, maps: [
-			['Phlegethon', 1.71, 2.56, 3.42], ['Fall of Caldeum', 1.62, 2.43, 3.24],
-			['Torajan Jungle', 1.60, 2.40, 3.19], ['Ancestral Trial', 1.54, 2.31, 3.08],
-			['Lost Temple', 1.49, 2.24, 2.98], ['Ruins of Viz-Jun', 1.37, 2.06, 2.74],
-			['Shadows of Westmarch', 1.36, 2.04, 2.72], ['Tomb of Zoltun Kulle', 1.29, 1.94, 2.59]
-		]}
-	];
-
-	var expNoneS13 = [
-		{ tier: 3, maps: [
-			['Kehjistan Marketplace', 4.42, 6.62, 8.83], ['Arreat Battlefield', 4.23, 6.34, 8.46],
-			['Demon Road', 4.03, 6.05, 8.07], ['River of Blood', 3.72, 5.58, 7.43],
-			['Bastion Keep', 3.65, 5.47, 7.30], ['Royal Crypts', 3.58, 5.37, 7.16],
-			['Blood Moon', 3.46, 5.19, 6.92], ['Skovos Stronghold', 'TBD', 'TBD', 'TBD'],
-			['Kyovoshad', 'TBD', 'TBD', 'TBD']
-		]},
-		{ tier: 2, maps: [
-			['Halls of Torture', 5.32, 7.98, 10.64], ['Pandemonium Citadel', 4.92, 7.38, 9.84],
-			['Ashen Plains', 4.92, 7.38, 9.84], ['Sanatorium', 4.41, 6.62, 8.82],
-			['Canyon of Sescheron', 4.19, 6.29, 8.38], ["Horazon's Memory", 4.10, 6.14, 8.19],
-			['Throne of Insanity', 4.00, 6.00, 8.00], ['Sewers of Harrogath', 3.94, 5.90, 7.87],
-			['Ruined Cistern', 3.61, 5.41, 7.22]
-		]},
-		{ tier: 1, maps: [
-			['Torajan Jungle', 4.73, 7.09, 9.46], ['Phlegethon', 4.50, 6.76, 9.01],
-			['Ancestral Trial', 4.05, 6.07, 8.10], ['Ruins of Viz-Jun', 4.01, 6.01, 8.01],
-			['Lost Temple', 3.73, 5.59, 7.46], ['Fall of Caldeum', 3.51, 5.26, 7.02],
-			['Tomb of Zoltun Kulle', 3.29, 4.93, 6.57], ['Shadows of Westmarch', 3.17, 4.75, 6.33]
-		]}
-	];
-
-	// Active dataset references — reassigned when season toggles
-	var mfData = mfDataS13, exp98 = exp98S13, expNone = expNoneS13;
+	var mfData = loadMfData(), exp98 = loadExp98(), expNone = loadExpNone();
 
 	// Element lookup shared across seasons (derived from current S13 data)
-	var mapElems = {};
-	mfDataS13.forEach(function(g) { g.maps.forEach(function(m) { mapElems[m.name] = m.elems; }); });
+	var mapElems = helpers.getS13Elems();
 
 	function getElemCells(name) {
 		var elems = mapElems[name] || [];
@@ -1932,14 +1797,24 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 		}
 	}
 
+	function reloadDatasets() {
+		mfData = loadMfData();
+		exp98 = loadExp98();
+		expNone = loadExpNone();
+	}
+
+	function updateSoloTypeToggleVisibility() {
+		var show = (currentSeason !== 'S12') && (getMode() === 'mf');
+		document.getElementById('mapTimesSoloTypeGroup').style.display = show ? '' : 'none';
+	}
+	updateSoloTypeToggleVisibility();
+
 	// Season toggle
 	document.querySelectorAll('input[name="mapTimesSeason"]').forEach(function(radio) {
 		radio.addEventListener('change', function() {
-			if (this.value === 'S12') {
-				mfData = mfDataS12; exp98 = exp98S12; expNone = expNoneS12;
-			} else {
-				mfData = mfDataS13; exp98 = exp98S13; expNone = expNoneS13;
-			}
+			currentSeason = this.value;
+			reloadDatasets();
+			updateSoloTypeToggleVisibility();
 			calcMapName = null; calcTimeSec = 0;
 			document.getElementById('mtCalcMapSelect').value = '';
 			document.getElementById('mtCalcMin').value = '';
@@ -1949,9 +1824,24 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 		});
 	});
 
-	// Tab changes
+	// Mode tab changes
 	document.querySelectorAll('input[name="mapTimesMode"]').forEach(function(radio) {
 		radio.addEventListener('change', function() {
+			updateSoloTypeToggleVisibility();
+			calcMapName = null; calcTimeSec = 0;
+			document.getElementById('mtCalcMapSelect').value = '';
+			document.getElementById('mtCalcMin').value = '';
+			document.getElementById('mtCalcSec').value = '';
+			populateDropdown(getMode());
+			render();
+		});
+	});
+
+	// Solo Type toggle (only relevant in MF mode on S13)
+	document.querySelectorAll('input[name="mapTimesSoloType"]').forEach(function(radio) {
+		radio.addEventListener('change', function() {
+			currentSoloType = this.value;
+			reloadDatasets();
 			calcMapName = null; calcTimeSec = 0;
 			document.getElementById('mtCalcMapSelect').value = '';
 			document.getElementById('mtCalcMin').value = '';

--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "April 24th 2026",
+  "updatedDate": "April 29th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "April 24th 2026",
+  "updatedDate": "April 29th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {

--- a/solo.html
+++ b/solo.html
@@ -743,6 +743,7 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 <script src="solo-data.js"></script>
+<script src="maps-data.js"></script>
 <script>
 
 	const classSvgs = {
@@ -1478,11 +1479,18 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 					maps</em>. The times below are the clear speed bars for each tier on each map.</p>
 				<p>Times are weighted by map tier and approximate monster count. Map size or layout does not factor into
 					the clear speeds &mdash; only the number of monsters in the map matters.</p>
-				<div class="btn-group btn-group-sm mb-3" role="group" aria-label="Season">
+				<div class="btn-group btn-group-sm mb-2" role="group" aria-label="Season">
 					<input type="radio" class="btn-check" name="soloSeason" id="soloSeasonS13" value="S13" checked>
 					<label class="btn btn-outline-info" for="soloSeasonS13">Season 13</label>
 					<input type="radio" class="btn-check" name="soloSeason" id="soloSeasonS12" value="S12">
 					<label class="btn btn-outline-info" for="soloSeasonS12">Season 12</label>
+				</div>
+				<br>
+				<div class="btn-group btn-group-sm mb-3" id="soloTypeGroup" role="group" aria-label="Solo Type">
+					<input type="radio" class="btn-check" name="soloType" id="soloTypeFull" value="fullClear" checked>
+					<label class="btn btn-outline-light" for="soloTypeFull">MF Full Clear</label>
+					<input type="radio" class="btn-check" name="soloType" id="soloTypeElite" value="eliteSkip">
+					<label class="btn btn-outline-light" for="soloTypeElite">MF Elite Skip</label>
 				</div>
 				<div class="card bg-secondary bg-opacity-25 p-3 mb-3">
 					<div class="row g-2 align-items-end">
@@ -1538,76 +1546,17 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 
 <script>
 	(function () {
-		var soloMapDataS12 = [
-			{ tier: 3, maps: [
-				{ name: 'Canyon of Sescheron', slug: 'canyon', top: '5:45', good: '8:35', decent: '11:25', elems: [{i:0,v:'120',c:'160,160,160'},{i:2,v:'130',c:'220,60,40'},{i:5,v:'110',c:'80,200,80'}] },
-				{ name: 'Phlegethon', slug: 'phlegethon', top: '5:20', good: '8:00', decent: '10:40', elems: [{i:2,v:'140',c:'220,60,40'},{i:3,v:'125',c:'220,200,40'}] },
-				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
-				{ name: 'Ashen Plains', slug: 'ashen', top: '4:30', good: '6:40', decent: '8:55', elems: [{i:1,v:'120',c:'180,80,220'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Kehjistan Marketplace', slug: 'marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-				{ name: 'Throne of Insanity', slug: 'throne', top: '4:00', good: '6:00', decent: '8:00', elems: [{i:2,v:'130',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Sanatorium', slug: 'sanatorium', top: '3:30', good: '5:10', decent: '6:55', elems: [{i:3,v:'125',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Ruined Cistern', slug: 'cistern', top: '3:10', good: '4:45', decent: '6:15', elems: [{i:1,v:'125',c:'180,80,220'},{i:3,v:'135',c:'220,200,40'},{i:4,v:'115',c:'60,140,220'}] },
-				{ name: 'Pandemonium Citadel', slug: 'citadel', top: '3:00', good: '4:25', decent: '5:55', elems: [{i:0,v:'100',c:'160,160,160'},{i:3,v:'135',c:'220,200,40'},{i:5,v:'130',c:'80,200,80'}] }
-			]},
-			{ tier: 2, maps: [
-				{ name: 'Ruins of Viz-Jun', slug: 'ruinsofvizjun', top: '3:30', good: '5:15', decent: '7:00', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-				{ name: 'Ancestral Trial', slug: 'ancestral', top: '3:25', good: '5:05', decent: '6:50', elems: [{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Tomb of Zoltun Kulle', slug: 'zoltun', top: '3:20', good: '5:00', decent: '6:45', elems: [{i:0,v:'105',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'110',c:'80,200,80'}] },
-				{ name: 'Bastion Keep', slug: 'bastion', top: '3:00', good: '4:30', decent: '6:00', elems: [{i:0,v:'110',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'River of Blood', slug: 'riverblood', top: '2:55', good: '4:25', decent: '5:50', elems: [{i:1,v:'100',c:'180,80,220'},{i:4,v:'180',c:'60,140,220'},{i:5,v:'130',c:'80,200,80'}] },
-				{ name: 'Demon Road', slug: 'demonroad', top: '2:50', good: '4:15', decent: '5:40', elems: [{i:4,v:'125',c:'60,140,220'},{i:5,v:'135',c:'80,200,80'}] },
-				{ name: 'Skovos Stronghold', slug: 'skovos', top: '2:25', good: '3:40', decent: '4:50', elems: [{i:0,v:'125',c:'160,160,160'},{i:2,v:'125',c:'220,60,40'},{i:3,v:'130',c:'220,200,40'}] },
-				{ name: 'Lost Temple', slug: 'losttemple', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'110',c:'60,140,220'}] }
-			]},
-			{ tier: 1, maps: [
-				{ name: 'Torajan Jungle', slug: 'torajanjungle', top: '4:00', good: '6:00', decent: '7:55', elems: [{i:2,v:'125',c:'220,60,40'},{i:3,v:'105',c:'220,200,40'}] },
-				{ name: 'Halls of Torture', slug: 'hallsoftorture', top: '3:35', good: '5:25', decent: '7:10', elems: [] },
-				{ name: "Horazon's Memory", slug: 'horazonsmemory', top: '3:25', good: '5:10', decent: '6:55', elems: [{i:2,v:'135',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', top: '3:00', good: '4:35', decent: '6:05', elems: [{i:2,v:'130',c:'220,60,40'},{i:3,v:'100',c:'220,200,40'}] },
-				{ name: 'Royal Crypts', slug: 'royalcrypts', top: '2:50', good: '4:20', decent: '5:45', elems: [{i:1,v:'150',c:'180,80,220'},{i:4,v:'125',c:'60,140,220'},{i:5,v:'105',c:'80,200,80'}] },
-				{ name: 'Sewers of Harrogath', slug: 'sewers', top: '2:45', good: '4:10', decent: '5:30', elems: [{i:3,v:'135',c:'220,200,40'},{i:5,v:'125',c:'80,200,80'}] },
-				{ name: 'Shadows of Westmarch', slug: 'westmarch', top: '2:40', good: '3:55', decent: '5:15', elems: [{i:0,v:'100',c:'160,160,160'},{i:5,v:'135',c:'80,200,80'}] },
-				{ name: 'Fall of Caldeum', slug: 'caldeum', top: '2:10', good: '3:15', decent: '4:20', elems: [{i:3,v:'100',c:'220,200,40'},{i:4,v:'130',c:'60,140,220'}] }
-			]}
-		];
+		var helpers = window.mapsDataHelpers;
+		var currentSeason = 'S13';
+		var currentType = 'fullClear';
 
-		var soloMapDataS13 = [
-			{ tier: 3, maps: [
-				{ name: 'Blood Moon', slug: 'bloodmoon', top: '5:15', good: '7:55', decent: '10:35', elems: [] },
-				{ name: 'Kehjistan Marketplace', slug: 'marketplace', top: '4:20', good: '6:30', decent: '8:35', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}] },
-				{ name: 'Bastion Keep', slug: 'bastion', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
-				{ name: 'Arreat Battlefield', slug: 'arreatbattlefield', top: '4:00', good: '6:05', decent: '8:05', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'River of Blood', slug: 'riverblood', top: '4:00', good: '5:55', decent: '7:55', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Demon Road', slug: 'demonroad', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-				{ name: 'Royal Crypts', slug: 'royalcrypts', top: '3:50', good: '5:45', decent: '7:35', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'120',c:'60,140,220'}] },
-				{ name: 'Skovos Stronghold', slug: 'skovos', top: 'TBD', good: 'TBD', decent: 'TBD', elems: [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Kyovoshad', slug: 'kyovoshad', top: 'TBD', good: 'TBD', decent: 'TBD', elems: [] }
-			]},
-			{ tier: 2, maps: [
-				{ name: 'Canyon of Sescheron', slug: 'canyon', top: '4:50', good: '7:20', decent: '9:45', elems: [{i:0,v:'115',c:'160,160,160'},{i:2,v:'120',c:'220,60,40'}] },
-				{ name: 'Halls of Torture', slug: 'hallsoftorture', top: '4:05', good: '6:05', decent: '8:05', elems: [{i:3,v:'120',c:'220,200,40'},{i:4,v:'120',c:'60,140,220'}] },
-				{ name: "Horazon's Memory", slug: 'horazonsmemory', top: '3:50', good: '5:50', decent: '7:45', elems: [{i:0,v:'115',c:'160,160,160'},{i:3,v:'120',c:'220,200,40'}] },
-				{ name: 'Ashen Plains', slug: 'ashen', top: '3:50', good: '5:40', decent: '7:35', elems: [{i:2,v:'120',c:'220,60,40'},{i:4,v:'130',c:'60,140,220'}] },
-				{ name: 'Throne of Insanity', slug: 'throne', top: '3:25', good: '5:05', decent: '6:50', elems: [{i:0,v:'115',c:'160,160,160'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Sewers of Harrogath', slug: 'sewers', top: '3:05', good: '4:40', decent: '6:10', elems: [{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Sanatorium', slug: 'sanatorium', top: '2:55', good: '4:25', decent: '5:55', elems: [{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Ruined Cistern', slug: 'cistern', top: '2:40', good: '4:00', decent: '5:20', elems: [{i:1,v:'105',c:'180,80,220'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Pandemonium Citadel', slug: 'citadel', top: '2:30', good: '3:45', decent: '5:00', elems: [{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] }
-			]},
-			{ tier: 1, maps: [
-				{ name: 'Phlegethon', slug: 'phlegethon', top: '3:55', good: '5:55', decent: '7:55', elems: [{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Torajan Jungle', slug: 'torajanjungle', top: '3:55', good: '5:50', decent: '7:45', elems: [{i:4,v:'120',c:'60,140,220'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Ruins of Viz-Jun', slug: 'ruinsofvizjun', top: '3:30', good: '5:15', decent: '7:00', elems: [{i:0,v:'115',c:'160,160,160'},{i:4,v:'120',c:'60,140,220'}] },
-				{ name: 'Ancestral Trial', slug: 'ancestral', top: '3:25', good: '5:05', decent: '6:45', elems: [{i:2,v:'120',c:'220,60,40'},{i:3,v:'120',c:'220,200,40'}] },
-				{ name: 'Tomb of Zoltun Kulle', slug: 'zoltun', top: '3:20', good: '5:00', decent: '6:40', elems: [{i:0,v:'115',c:'160,160,160'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Shadows of Westmarch', slug: 'westmarch', top: '2:35', good: '3:50', decent: '5:10', elems: [{i:1,v:'105',c:'180,80,220'},{i:2,v:'120',c:'220,60,40'},{i:5,v:'120',c:'80,200,80'}] },
-				{ name: 'Lost Temple', slug: 'losttemple', top: '2:20', good: '3:30', decent: '4:40', elems: [{i:1,v:'105',c:'180,80,220'},{i:4,v:'120',c:'60,140,220'}] },
-				{ name: 'Fall of Caldeum', slug: 'caldeum', top: '2:05', good: '3:10', decent: '4:15', elems: [{i:0,v:'115',c:'160,160,160'},{i:1,v:'105',c:'180,80,220'},{i:3,v:'120',c:'220,200,40'}] }
-			]}
-		];
+		function loadSoloMapData() {
+			return currentSeason === 'S12'
+				? window.mapsData.s12.mfData
+				: helpers.buildS13MfData(currentType);
+		}
 
-		var soloMapData = soloMapDataS13;
+		var soloMapData = loadSoloMapData();
 
 		function parseTime(str) {
 			var parts = str.split(':');
@@ -1690,15 +1639,35 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 		}
 		populateSoloDropdown();
 
+		function reloadSoloData() {
+			soloMapData = loadSoloMapData();
+			document.getElementById('soloCalcMapSelect').value = '';
+			document.getElementById('soloCalcMin').value = '';
+			document.getElementById('soloCalcSec').value = '';
+			populateSoloDropdown();
+			renderSoloTierTable(null, 0);
+		}
+
+		// Solo Type toggle is only meaningful for S13
+		function updateTypeToggleVisibility() {
+			document.getElementById('soloTypeGroup').style.display = (currentSeason === 'S12') ? 'none' : '';
+		}
+		updateTypeToggleVisibility();
+
 		// Season toggle
 		document.querySelectorAll('input[name="soloSeason"]').forEach(function(radio) {
 			radio.addEventListener('change', function() {
-				soloMapData = (this.value === 'S12') ? soloMapDataS12 : soloMapDataS13;
-				document.getElementById('soloCalcMapSelect').value = '';
-				document.getElementById('soloCalcMin').value = '';
-				document.getElementById('soloCalcSec').value = '';
-				populateSoloDropdown();
-				renderSoloTierTable(null, 0);
+				currentSeason = this.value;
+				updateTypeToggleVisibility();
+				reloadSoloData();
+			});
+		});
+
+		// Solo Type toggle
+		document.querySelectorAll('input[name="soloType"]').forEach(function(radio) {
+			radio.addEventListener('change', function() {
+				currentType = this.value;
+				reloadSoloData();
 			});
 		});
 


### PR DESCRIPTION
## Summary
- New **MF Full Clear** (default) / **MF Elite Skip** toggle on solo.html and maps.html for S13. Group view (EXP only) is unchanged.
- All S13 map clear times refreshed from new formula and rounded to nearest 5 seconds.
- Single shared `maps-data.js` is now the source of truth for all map clear-time/EXP/element data — solo.html, maps.html, group.html all read from it. Eliminates ~350 lines of triplicated S13/S12 datasets.
- Skovos Stronghold and Kyovoshad remain TBD (no measured data yet).

## Test plan
- [ ] solo.html → Tier modal: MF Full Clear shows new (longer) times by default; toggling MF Elite Skip switches to shorter times.
- [ ] maps.html → Map Times modal: same toggle works in MF mode; toggle hides in EXP modes and on S12.
- [ ] group.html → Map Times modal still shows EXP/hr (Lvl 98 / No Penalty) tables, season toggle still works.
- [ ] Calculator (your-time → ratio extrapolation) still works on all three pages.
- [ ] S12 archive view unchanged on all three pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)