### PR TITLE
Fix #199: correct eth + ED interaction in dmg-calc

### DIFF
--- a/dmg-calc.html
+++ b/dmg-calc.html
@@ -128,7 +128,7 @@
 					<div class="col-4 d-flex align-items-end">
 						<div class="form-check mb-1">
 							<input class="form-check-input" type="checkbox" id="a_eth" onchange="calc()">
-							<label class="form-check-label form-label" for="a_eth">Ethereal (+25%)</label>
+							<label class="form-check-label form-label" for="a_eth">Ethereal (1.25x base)</label>
 						</div>
 					</div>
 				</div>
@@ -411,7 +411,7 @@
 					<div class="col-4 d-flex align-items-end">
 						<div class="form-check mb-1">
 							<input class="form-check-input" type="checkbox" id="b_eth" onchange="calc()">
-							<label class="form-check-label form-label" for="b_eth">Ethereal (+25%)</label>
+							<label class="form-check-label form-label" for="b_eth">Ethereal (1.25x base)</label>
 						</div>
 					</div>
 				</div>
@@ -678,7 +678,7 @@
 
 	<p class="text-secondary text-center mt-2" style="font-size:0.75rem">
 		Weapon base damages are approximate PD2 values. Verify in-game for exact numbers.
-		Ethereal = +25% weapon ED. Flat +damage added after weapon ED multiplier.
+		Ethereal = 1.25x base damage (multiplicative, applied before weapon ED). Flat +damage added after weapon ED multiplier.
 		Crit and DS each independently roll for their respective multiplier.
 	</p>
 </div>
@@ -919,11 +919,12 @@
 		const fpa      = Math.max(1, n(p+'_fpa', 8));
 		const dpsOn    = b(p+'_dps_on');
 
-		// 1. Weapon damage (eth stacks additively with weapon ED)
-		const ethBonus    = eth ? 25 : 0;
-		const totalWED    = wed + ethBonus;
-		const wepMin      = Math.floor(baseMin * (1 + totalWED / 100)) + flatMin;
-		const wepMax      = Math.floor(baseMax * (1 + totalWED / 100)) + flatMax;
+		// 1. Weapon damage (eth multiplies base damage by 1.25x BEFORE weapon ED)
+		const ethMult     = eth ? 1.25 : 1.0;
+		const ethBaseMin  = Math.floor(baseMin * ethMult);
+		const ethBaseMax  = Math.floor(baseMax * ethMult);
+		const wepMin      = Math.floor(ethBaseMin * (1 + wed / 100)) + flatMin;
+		const wepMax      = Math.floor(ethBaseMax * (1 + wed / 100)) + flatMax;
 		const wepAvg      = (wepMin + wepMax) / 2;
 
 		// 2. Off-weapon ED


### PR DESCRIPTION
## Summary

The Ethereal checkbox in `dmg-calc.html` was treating eth as a flat `+25` added to the weapon's ED total (same multiplicative bracket as item ED). The correct PD2 behavior is that eth applies a separate multiplicative `1.25x` to base weapon damage **before** ED is applied.

## Formula change

Before:
```js
const ethBonus = eth ? 25 : 0;
const totalWED = wed + ethBonus;
const wepMin   = floor(baseMin * (1 + totalWED/100)) + flatMin;
```

After:
```js
const ethMult    = eth ? 1.25 : 1.0;
const ethBaseMin = floor(baseMin * ethMult);
const wepMin     = floor(ethBaseMin * (1 + wed/100)) + flatMin;
```

## Worked example (issue's case)

Eth War Pike (41-223), +545% ED, no flat:

| Step | Before (bug) | After (fix) |
|------|--------------|-------------|
| min  | floor(41 * (1+5.70))=274 | floor(41*1.25)=51 → floor(51*6.45)=328 |
| max  | floor(223 * (1+5.70))=1494 | floor(223*1.25)=278 → floor(278*6.45)=1793 |
| **avg** | **884** | **1060.5** |

Matches the user-expected value of 1060.5 exactly.

The on-screen label and footnote were also updated from "Ethereal (+25%)" to "Ethereal (1.25x base)" to reflect the actual mechanic.

Closes #199

## Test plan

- [ ] Load https://maaaaaarrk.github.io/Hiim-PD2-Resources/dmg-calc.html with the URL from the issue (eth War Pike 41-223, 545% ED) and confirm avg weapon dmg shows 1060.5
- [ ] Toggle eth off and confirm avg drops to 851 (132 * 6.45 floored)
- [ ] Sanity-check a non-eth weapon to ensure non-eth path is unchanged