### PR TITLE
Add #203: Amazon Lightning Fury — Tomb of Zoltun Kulle clear (2:52)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "May 3rd 2026",
+  "updatedDate": "May 4th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1437,6 +1437,12 @@ window.soloData = {
           {
             "url": "https://www.youtube.com/watch?v=NoYaBlRbryU",
             "label": "Phlegethon (4:00)",
+            "type": "video",
+            "season": 13
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=r9oHhMfmWqY",
+            "label": "Tomb of Zoltun Kulle (2:52)",
             "type": "video",
             "season": 13
           }

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "May 3rd 2026",
+  "updatedDate": "May 4th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1437,6 +1437,12 @@
           {
             "url": "https://www.youtube.com/watch?v=NoYaBlRbryU",
             "label": "Phlegethon (4:00)",
+            "type": "video",
+            "season": 13
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=r9oHhMfmWqY",
+            "label": "Tomb of Zoltun Kulle (2:52)",
             "type": "video",
             "season": 13
           }


### PR DESCRIPTION
## Summary
- Adds a new video link to the Amazon Lightning Fury build in `solo-data.js` and `solo-data.json`: Tomb of Zoltun Kulle clear in 2:52 (https://www.youtube.com/watch?v=r9oHhMfmWqY).
- Submitted by @Homelab123 — thanks!
- Bumps `updatedDate` to "May 4th 2026" (user-local day).
- Tier remains `Top` (Tier 1 map; 2:52 is well under the 3:20 Top threshold).

Closes #203

## Test plan
- [ ] `solo.html` renders the new "Tomb of Zoltun Kulle (2:52)" video link under Amazon → Lightning Fury
- [ ] `solo-data.json` parses as valid JSON
- [ ] Updated banner reflects May 4th 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)