### PR TITLE
Add Season 13 race time (2d 10.5h) to ticker and modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,7 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 					<div class="title"><h3 style="text-align: center;"><a href="#" class="alert-link" data-bs-toggle="modal" data-bs-target="#raceChartModal">Hiim 99 Race Records 📊</a></h3></div>
 					<div class="ticker-wrap">
 						<div class="ticker-content">
+							<span class="badge text-bg-dark">Season 13 — 2 Days 10.5 Hours</span>
 							<span class="badge text-bg-secondary">Season 12 — 2 Days 10 Hours</span>
 							<span class="badge text-bg-dark">Season 11 — 2 Days 11 Hours</span>
 							<span class="badge text-bg-secondary">Season 10 — 4 Days 6.5 Hours</span>
@@ -465,6 +466,7 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 <script>
 	(function () {
 		const data = [
+			{ label: 'Season 13',          hours: 2*24 + 10.5 },
 			{ label: 'Season 12',          hours: 2*24 + 10   },
 			{ label: 'Season 11',          hours: 2*24 + 11   },
 			{ label: 'Season 10',          hours: 4*24 + 6.5  },


### PR DESCRIPTION
## Summary
- Adds Season 13 entry (2 Days 10.5 Hours) to the 99 Race Records ticker on `index.html`.
- Adds Season 13 to the `data` array powering the Race Chart modal so it appears in the comparison chart.

Closes #205

## Test plan
- [ ] Open `index.html` and confirm the ticker scroll shows "Season 13 - 2 Days 10.5 Hours" as the first badge.
- [ ] Click the "Hiim 99 Race Records" link to open the modal and confirm Season 13 appears at the top of the chart with a "2d 10.5h" datalabel.