### PR TITLE
Show raw damage delta alongside % in dmg parity table

### DIFF
--- a/dmg-calc.html
+++ b/dmg-calc.html
@@ -1273,8 +1273,13 @@
 			: null;
 		const csCapHeadroom = 100 - crit;
 
+		// Raw avg-damage delta from +40% off-weapon ED. Off-wep ED scales effAvg by (1+X);
+		// CB doesn't scale, so the absolute increase in Total Avg / hit is effAvg * X.
+		const rawDelta = r.effAvg * X;
+
 		return {
 			X, valid: true,
+			rawDelta,
 			onWedParity,
 			flatParity,
 			dsParity,
@@ -1331,7 +1336,7 @@
 				</tbody>
 			</table>
 			<hr class="my-2">
-			<div class="result-row"><span class="lbl"><strong>Final Damage Increase</strong></span><span class="val pos"><strong>${Xpct.toFixed(1)}%</strong></span></div>
+			<div class="result-row"><span class="lbl"><strong>Final Damage Increase</strong></span><span class="val pos"><strong>${Xpct.toFixed(1)}%</strong> <small>(+${fmt(par.rawDelta, 1)} avg dmg)</small></span></div>
 		`;
 	}
 


### PR DESCRIPTION
Follow-up to #209 / #210.

Per user request, the "Final Damage Increase" line under each weapon's parity table now shows the raw average-damage delta in addition to the existing percentage.

Format:

```
Final Damage Increase: 12.3% (+45.0 avg dmg)
```

The raw delta is computed as `r.effAvg * X`, i.e. the absolute increase in average damage that the baseline +40% off-weapon ED produces (Crushing Blow doesn't scale with off-wep ED, so it's effAvg, not totalAvg). For builds without CB this matches the change in "Total Avg / hit" exactly.

N/A is unchanged: when the parity calc returns invalid (no weapon configured), the whole panel renders the existing N/A message and the raw delta line is never rendered.