### PR TITLE
Fix #212: add Combustion Sorc clear video (Tombs of Zoltun)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "May 4th 2026",
+  "updatedDate": "May 7th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -628,6 +628,12 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=4274s",
             "label": "Starter Guide (1:11:14)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=7LodwzmIBDE&t=270s",
+            "label": "Tombs of Zoltun (4:30)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "May 4th 2026",
+  "updatedDate": "May 7th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -628,6 +628,12 @@
             "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=4274s",
             "label": "Starter Guide (1:11:14)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=7LodwzmIBDE&t=270s",
+            "label": "Tombs of Zoltun (4:30)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []


### PR DESCRIPTION
Closes #212

## Change
Adds a Tombs of Zoltun clear video to the Sorceress / Combustion entry on the Solo tier list.

Files: `solo-data.json` and `solo-data.js` (kept in sync). Bumped top-level `updatedDate` to `May 7th 2026`.

## Snippet added
```json
{
  "url": "https://www.youtube.com/watch?v=7LodwzmIBDE&t=270s",
  "label": "Tombs of Zoltun (4:30)",
  "type": "video",
  "season": 13
}
```

The 4:30 timestamp is encoded into the URL as `&t=270s` (matching the existing `Starter Guide` link's pattern) and surfaced in the label `(4:30)`. The per-link `"season": 13` tag matches existing season-tagged video entries (e.g. Druid Fire Elemental "Build Guide"). Combustion remains tier "Good" (unchanged).