### PR TITLE
Fix #214: Add MF Ear clear-time option

### DIFF
--- a/maps-data.js
+++ b/maps-data.js
@@ -1,6 +1,7 @@
 // Shared maps data — used by solo.html, maps.html, group.html
 // Time values are decimal minutes (e.g. 4.39 = 4 min 23.4s). Consumers round to nearest 5s.
 // `mfFullClear` = default Solo MF (full clear). `mfEliteSkip` = alternative Solo MF (elite skip).
+// `ear` variant is derived: `mfFullClear * 1.5` (Ear runs take 50% longer per mob since mobs drop 50% more loot).
 window.mapsData = {
 	season: 13,
 
@@ -236,13 +237,18 @@ window.mapsDataHelpers = {
 	},
 
 	// Build tier-grouped Solo/MF dataset for S13 in `{tier, maps:[{name,slug,top,good,decent,elems}]}` shape.
-	// `variant` is 'fullClear' (default) or 'eliteSkip'.
+	// `variant` is 'fullClear' (default), 'eliteSkip', or 'ear'.
+	// 'ear' is derived from mfFullClear * 1.5 (Ear runs spend 50% longer per mob since mobs drop 50% more loot).
 	buildS13MfData: function (variant) {
 		var fmt = this.fmtMin;
 		var field = variant === 'eliteSkip' ? 'mfEliteSkip' : 'mfFullClear';
+		var earMultiplier = (variant === 'ear') ? 1.5 : 1;
 		var byTier = { 3: [], 2: [], 1: [] };
 		window.mapsData.s13.forEach(function (m) {
-			var arr = m[field];
+			var raw = m[field];
+			var arr = (raw && earMultiplier !== 1)
+				? [raw[0] * earMultiplier, raw[1] * earMultiplier, raw[2] * earMultiplier]
+				: raw;
 			byTier[m.tier].push({
 				name: m.name, slug: m.slug, elems: m.elems,
 				top: fmt(arr ? arr[0] : null),

--- a/maps.html
+++ b/maps.html
@@ -1580,6 +1580,8 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 					<label class="btn btn-outline-light" for="mapTimesSoloTypeFull">MF Full Clear</label>
 					<input type="radio" class="btn-check" name="mapTimesSoloType" id="mapTimesSoloTypeElite" value="eliteSkip">
 					<label class="btn btn-outline-light" for="mapTimesSoloTypeElite">MF Elite Skip</label>
+					<input type="radio" class="btn-check" name="mapTimesSoloType" id="mapTimesSoloTypeEar" value="ear">
+					<label class="btn btn-outline-light" for="mapTimesSoloTypeEar">MF Ear</label>
 				</div>
 				<div id="mapTimesDesc"></div>
 				<div class="card bg-secondary bg-opacity-25 p-3 mb-3">

--- a/solo.html
+++ b/solo.html
@@ -1491,6 +1491,8 @@ m17 -46 c-3 -10 -2 -18 2 -17 3 1 7 -1 9 -5 1 -5 0 -8 -3 -8 -3 0 -11 0 -19 0
 					<label class="btn btn-outline-light" for="soloTypeFull">MF Full Clear</label>
 					<input type="radio" class="btn-check" name="soloType" id="soloTypeElite" value="eliteSkip">
 					<label class="btn btn-outline-light" for="soloTypeElite">MF Elite Skip</label>
+					<input type="radio" class="btn-check" name="soloType" id="soloTypeEar" value="ear">
+					<label class="btn btn-outline-light" for="soloTypeEar">MF Ear</label>
 				</div>
 				<div class="card bg-secondary bg-opacity-25 p-3 mb-3">
 					<div class="row g-2 align-items-end">


### PR DESCRIPTION
## Summary

Adds a third Magic Find clear-time variant (**MF Ear**) alongside the existing **MF Full Clear** and **MF Elite Skip** options on both `maps.html` (Magic Find section of the map-times modal) and `solo.html` (solo tier list modal).

Per issue #214: MF Ear runs use the same raw values as MF Full Clear, but with **+50% time across the board** because mobs drop 50% more loot during Ear runs (so the player kills/chunks slower per mob).

## How values are computed

- **No new per-map data field.** MF Ear is **derived at render time** in `buildS13MfData('ear')` (in `maps-data.js`) by multiplying each `mfFullClear` triplet by **1.5**.
- This keeps `maps-data.js` as the single source of truth for raw clear times — when MF Full values are updated, MF Ear stays correct automatically.
- The display formatter `fmtMin` already rounds to the nearest 5 seconds, so no special rounding is added here. Example: Marketplace MF Full top time `4.95` min ?? 1.5 = `7.425` min ?? rounded to `7:25`.

## Files changed

- `maps-data.js` ?? `buildS13MfData` accepts a third variant `'ear'`; comment header updated.
- `maps.html` ?? third radio button **MF Ear** added under the Magic Find Solo Type group (`mapTimesSoloType`). The existing toggle handler already reads the new value.
- `solo.html` ?? third radio button **MF Ear** added under the Solo Type group (`soloType`). Existing handler already reads the new value.

## Judgment calls

- **Label phrasing:** used **"MF Ear"** (matching issue wording and the existing "MF Full Clear" / "MF Elite Skip" tone).
- **Data approach:** chose derived (helper does the multiplication) over per-map fields, since it's a strict 1.5x transform and adding 26 redundant per-map arrays would be noisy and easy to drift.
- **Rounding:** values are multiplied as raw decimal minutes, then `fmtMin` rounds to nearest 5s at display time ?? same pipeline as MF Full / MF Elite.

## Test plan

- [ ] Open `maps.html`, click the map-times modal, switch to Magic Find mode ?? confirm three radio buttons (Full Clear / Elite Skip / Ear) are visible.
- [ ] Click **MF Ear** ?? verify times are visibly ~1.5x longer than MF Full Clear and table re-sorts correctly.
- [ ] Open `solo.html`, open the solo tier modal ?? same three-button toggle, verify MF Ear works.
- [ ] Confirm S12 (which has no Ear variant) still hides the Solo Type group entirely.
- [ ] Confirm "Calculate your times" ratio math still works in MF Ear mode.

Closes #214