### PR TITLE
Add Fire Arrow Kyovashan map clear video (4:44)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "May 7th 2026",
+  "updatedDate": "May 10th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1542,6 +1542,12 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=2QFkwCfCls4",
             "label": "Pandemonium Citadel (4:37)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=h3VNKM7ZEOo",
+            "label": "Kyovashan Map (4:44)",
+            "type": "video",
+            "season": 13
           },
           {
             "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=1966s",

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "May 7th 2026",
+  "updatedDate": "May 10th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1542,6 +1542,12 @@
             "url": "https://www.youtube.com/watch?v=2QFkwCfCls4",
             "label": "Pandemonium Citadel (4:37)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=h3VNKM7ZEOo",
+            "label": "Kyovashan Map (4:44)",
+            "type": "video",
+            "season": 13
           },
           {
             "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=1966s",


### PR DESCRIPTION
## Summary
- Add new video evidence to Amazon Fire Arrow build in `solo-data` (Solo tier list): Kyovashan Map clear (4:44) by seanmckenna777-maker.
- Includes `"season": 13` per repo convention.
- Bump `updatedDate` to "May 10th 2026" in both `solo-data.js` and `solo-data.json`.

Closes #216

## Test plan
- [ ] Verify Fire Arrow row on solo.html shows the new "Kyovashan Map (4:44)" video link.
- [ ] Confirm "Updated — May 10th 2026" banner.