### PR TITLE
Fix #217: Add Sanctuary Sacrifice Ancestral Trial video (4:33)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "May 7th 2026",
+  "updatedDate": "May 10th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -2043,6 +2043,12 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=2587s",
             "label": "Build Guide (43:07)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=LqkZNiK8wAY",
+            "label": "Ancestral Trial (4:33)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "May 7th 2026",
+  "updatedDate": "May 10th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -2043,6 +2043,12 @@
             "url": "https://www.youtube.com/watch?v=VwH8rsODV-Q&t=2587s",
             "label": "Build Guide (43:07)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=LqkZNiK8wAY",
+            "label": "Ancestral Trial (4:33)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []


### PR DESCRIPTION
## Summary
- Adds an Ancestral Trial (4:33) video link to the existing Paladin "Sanctuary Sacrifice" build (tier: Good) in `solo-data.js` and `solo-data.json`.
- Bumps `updatedDate` to "May 10th 2026" in both files.

Closes #217

Submitted by @PWHjort87.

## Test plan
- [ ] solo.html loads and the new link shows under Paladin -> Sanctuary Sacrifice
- [ ] Banner reads "Updated - May 10th 2026"