### PR TITLE
Fix #220: Add second video link to Barbarian Travbarb

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "May 10th 2026",
+  "updatedDate": "May 11th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1233,6 +1233,12 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=cNT5BRgBELY&t=4297s",
             "label": "Build Guide (1:11:37)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=2J_s9QTFl10",
+            "label": "Play Guide",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "May 10th 2026",
+  "updatedDate": "May 11th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1233,6 +1233,12 @@
             "url": "https://www.youtube.com/watch?v=cNT5BRgBELY&t=4297s",
             "label": "Build Guide (1:11:37)",
             "type": "video"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=2J_s9QTFl10",
+            "label": "Play Guide",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []


### PR DESCRIPTION
Closes #220.

Adds the play-guide video (https://www.youtube.com/watch?v=2J_s9QTFl10) as a second link on the Barbarian Travbarb build entry alongside the existing Build Guide. Per-link `season: 13` field included. Mirrored in `solo-data.json` and `solo-data.js`. File-level `updatedDate` bumped to `May 11th 2026`.