### PR TITLE
Increase Ear map clear multiplier from 50% to 75%

### DIFF
--- a/maps-data.js
+++ b/maps-data.js
@@ -1,7 +1,7 @@
 // Shared maps data — used by solo.html, maps.html, group.html
 // Time values are decimal minutes (e.g. 4.39 = 4 min 23.4s). Consumers round to nearest 5s.
 // `mfFullClear` = default Solo MF (full clear). `mfEliteSkip` = alternative Solo MF (elite skip).
-// `ear` variant is derived: `mfFullClear * 1.5` (Ear runs take 50% longer per mob since mobs drop 50% more loot).
+// `ear` variant is derived: `mfFullClear * 1.75` (Ear runs take 75% longer per mob since mobs drop more loot).
 window.mapsData = {
 	season: 13,
 
@@ -238,11 +238,11 @@ window.mapsDataHelpers = {
 
 	// Build tier-grouped Solo/MF dataset for S13 in `{tier, maps:[{name,slug,top,good,decent,elems}]}` shape.
 	// `variant` is 'fullClear' (default), 'eliteSkip', or 'ear'.
-	// 'ear' is derived from mfFullClear * 1.5 (Ear runs spend 50% longer per mob since mobs drop 50% more loot).
+	// 'ear' is derived from mfFullClear * 1.75 (Ear runs spend 75% longer per mob since mobs drop more loot).
 	buildS13MfData: function (variant) {
 		var fmt = this.fmtMin;
 		var field = variant === 'eliteSkip' ? 'mfEliteSkip' : 'mfFullClear';
-		var earMultiplier = (variant === 'ear') ? 1.5 : 1;
+		var earMultiplier = (variant === 'ear') ? 1.75 : 1;
 		var byTier = { 3: [], 2: [], 1: [] };
 		window.mapsData.s13.forEach(function (m) {
 			var raw = m[field];


### PR DESCRIPTION
## Summary
- Update Ear variant multiplier in `maps-data.js` from `1.5` → `1.75` so Ear-run times reflect 75% longer per mob (was 50%).
- Refresh inline comments to match.

Affects the **MF Ear** option in `solo.html` and `maps.html` (S13 map times).

## Test plan
- [ ] Open `solo.html`, toggle **MF Ear** in the tier modal — times should be ~75% higher than **MF Full Clear** (e.g. Marketplace top tier ~4:55 → ~8:40).
- [ ] Open `maps.html`, toggle **MF Ear** — same verification.
- [ ] **MF Full Clear** and **MF Elite Skip** times are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)