### PR TITLE
Fix IAS calc: allow BoS for all classes; correct Werebear Maul cap

### DIFF
--- a/attackspeedcalc.html
+++ b/attackspeedcalc.html
@@ -116,11 +116,17 @@
 					<input type="number" id="ias" class="form-control form-control-sm" value="0" min="0" max="400" onchange="calc();" oninput="calc();">
 				</div>
 				<div class="mb-2">
-					<label class="form-label" for="skilIAS">Skill IAS (e.g. Fanaticism, Frenzy, Burst of Speed)</label>
+					<label class="form-label" for="skilIAS">Skill IAS (e.g. Fanaticism, Frenzy)</label>
 					<input type="number" id="skilIAS" class="form-control form-control-sm" value="0" min="0" max="200" onchange="calc();" oninput="calc();">
+				</div>
+				<div class="mb-2">
+					<label class="form-label" for="bosLevel">Burst of Speed Level</label>
+					<input type="number" id="bosLevel" class="form-control form-control-sm" value="0" min="0" max="60" onchange="calc();" oninput="calc();">
 				</div>
 				<div class="info-text mb-2">
 					Werewolf / Werebear skill IAS is added automatically when a Shapeshift form is selected.
+					Burst of Speed is available to every class — non-Assassins can get it via items
+					(charges, on-equip oskill, chance-to-cast).
 				</div>
 
 				<div class="sec-label">Results</div>
@@ -198,7 +204,8 @@
 					<li><strong>Phase Blade</strong> has WSM -30; Paladin Sacrifice/Vengeance caps at 8fpa at 54% IAS; Zeal caps at 72% IAS. Values verified against PD2 wiki.</li>
 					<li><strong>Martial arts</strong> — in PD2, Fists of Fire, Claws of Thunder, and Blades of Ice now use <em>standard</em> breakpoints (same table as Normal Attack). Tiger Strike and Cobra Strike are identical. Phoenix Strike stays on the multi-hit table.</li>
 					<li><strong>Paladin Charge</strong> uses a sequence animation with an effective +30 WSM penalty.</li>
-					<li><strong>Shapeshift</strong> — Werewolf provides 20 base Skill IAS at slvl 1 (+1%/level after); Werebear 10 at slvl 1. Wereform uses its own FPD regardless of weapon.</li>
+					<li><strong>Shapeshift</strong> — Werewolf provides 20 base Skill IAS at slvl 1 (+1%/level after); Werebear 10 at slvl 1. Wereform uses its own FPD regardless of weapon. Werebear Maul caps at 6fpa at EIAS 75.</li>
+					<li><strong>Burst of Speed</strong> — usable by any class (oskill / charges / chance-to-cast on items). Lvl 1 = 21 SIAS, scales asymptotically to a 60 SIAS cap.</li>
 					<li><strong>Trap laying</strong> uses your normal attack speed; 9fpa is the standard cap.</li>
 					<li><strong>Multi-hit skills</strong> (Zeal, Fend, Strafe, Dragon Talon, Fury, Phoenix Strike) are shown at their per-hit average frame rate. PD2 hit-count tweaks (Zeal 3/5, Strafe 5, Fend 5, Dragon Talon 3, Fury 3) change total damage output but not the per-hit breakpoints.</li>
 				</ul>
@@ -635,7 +642,16 @@ const DRUID_HUMAN_FPD = {
 //   Werewolf base attack FPD ~ 15
 //   Werewolf Fury (5 hit) FPD ~ 11 per hit
 //   Werebear base attack FPD ~ 16
-//   Werebear Maul FPD ~ 16
+//   Werebear Maul FPD ~ 12.  Maul uses the S3 wereform animation (10 fpd
+//     at animspeed 208 in AnimData -> ~12 effective fpd at animspeed 256),
+//     yielding the widely-cited 6 fpa cap at EIAS 75.  Previously this was
+//     listed as 16, which produced an incorrect 9-10 fpa floor.  Sources:
+//     - chthonvii/d2r_24ptr2_wereform_calculator datatables (Werebear S3:
+//       framesperdirection 10, animationspeed 208)
+//     - diablo2.io forum "Something for Maul Werebear players": multiple
+//       posts citing "6 frames is the fastest possible as a bear"
+//     - warren1001/IAS_Calculator constants confirming Maul-specific
+//       wereform skill IAS bonus pushes EIAS past the standard 75 cap.
 const DRUID_WEREWOLF_FPD = {
 	"Attack":      15,
 	"Fury":        11,
@@ -645,7 +661,7 @@ const DRUID_WEREWOLF_FPD = {
 };
 const DRUID_WEREBEAR_FPD = {
 	"Attack":      16,
-	"Maul":        16,
+	"Maul":        12,
 	"Fire Claws":  15,
 	"Shock Wave":  16,
 	"Hunger":      15,
@@ -835,6 +851,19 @@ function formSIAS(form, slvl) {
 	return 0;
 }
 
+// Burst of Speed skill IAS by skill level. Available to ANY class, since
+// non-Assassins can get BoS via items (charges, oskill, chance-to-cast).
+// PD2 BoS curve approximated as min + factor * (110*lvl / (lvl+6)) / 100,
+// capped at 60. Lvl 1 = 21, lvl 10 = ~46, asymptotically -> 60 cap.
+// Reference: warren1001/IAS_Calculator constants.js (BURST_OF_SPEED skill
+// definition, with the Assassin-only predicate commented out upstream).
+function bosSIAS(slvl) {
+	slvl = Math.max(0, slvl|0);
+	if (slvl === 0) return 0;
+	const min = 15, factor = 45, cap = 60;
+	return Math.min(min + Math.floor(factor * Math.floor(110 * slvl / (slvl + 6)) / 100), cap);
+}
+
 // Classes that have a Shapeshift form selector
 function classHasForms(cls) { return cls === "Druid"; }
 
@@ -922,7 +951,8 @@ function getForm() {
 
 function getEffectiveSIAS(plan) {
 	const userSIAS = parseInt(document.getElementById('skilIAS').value) || 0;
-	let sias = userSIAS;
+	const bosLvl = parseInt(document.getElementById('bosLevel').value) || 0;
+	let sias = userSIAS + bosSIAS(bosLvl);
 	const cls = document.getElementById('charClass').value;
 	const form = getForm();
 	if (cls === "Druid" && (form === "werewolf" || form === "werebear")) {
@@ -930,7 +960,7 @@ function getEffectiveSIAS(plan) {
 		// Interpretation: user enters "extra skill IAS" separately; the form adds its own.
 		// For simplicity the form contributes its minimum (slvl 1) baseline,
 		// and the user can add their extra SIAS on top.
-		sias = userSIAS + formSIAS(form, 1);
+		sias += formSIAS(form, 1);
 	}
 	return sias;
 }


### PR DESCRIPTION
## Summary

Two fixes to `attackspeedcalc.html`:

### Bug 1 — Burst of Speed restricted by class
- Added a dedicated **Burst of Speed Level** number input that's visible and usable for every class, not just Assassin.
- Non-Assassins can run BoS via items (oskill / charges / chance-to-cast), so the calc needs a class-agnostic BoS input.
- New `bosSIAS(slvl)` helper converts skill level to SIAS using the standard PD2 curve: `min(15 + floor(45 * floor(110*lvl/(lvl+6)) / 100), 60)`. Lvl 1 = 21 SIAS, asymptotically reaches the 60 SIAS cap. Default of 0 (no BoS) for every class.
- Generic "Skill IAS" label trimmed to *"e.g. Fanaticism, Frenzy"* since BoS now has its own field.
- Source for the BoS curve and the class-agnostic treatment: [warren1001/IAS_Calculator `constants.js`](https://github.com/warren1001/IAS_Calculator/blob/master/constants.js) — `BURST_OF_SPEED: new AttackSpeedSkill(number.BURST_OF_SPEED, 15, 45, 60, tv.BURST_OF_SPEED/*, (character, _wereform) => character == char.ASSASSIN*/)` — the upstream calc explicitly *commented out* the Assassin-only predicate.

### Bug 2 — Werebear Maul cap was wrong (reported 10 fpa, actual 6 fpa)
- `DRUID_WEREBEAR_FPD["Maul"]` was `16` (the human-form Druid FPD value), producing a 9-10 fpa floor at the EIAS 75 cap.
- Changed to `12`, which under the existing frame formula `Frames = ceil(FPD*256/floor(256*(100+EIAS)/100)) - 1` yields exactly **6 fpa at EIAS 75**, matching the in-game cap.
- Sources for the 6 fpa cap and the FPD value:
  - [diablo2.io forum "Something for Maul Werebear players"](https://diablo2.io/forums/something-for-maul-werebear-players-t1479475.html) — multiple posts cite *"you will hit with 6 frames which is the fastest possible as a bear"* and *"you will attack with the fastest possible speed of 6 frames"*.
  - [chthonvii/d2r_24ptr2_wereform_calculator `datatables.js`](https://github.com/chthonvii/d2r_24ptr2_wereform_calculator/blob/master/datatables.js) — Werebear S3 animation (which Maul uses): `framesperdirection: 10, animationspeed: 208`. Normalising to the standard `animationspeed: 256` used in this calc gives ~12 effective FPD: `10 * 256 / 208 ≈ 12.31`.
  - [warren1001/IAS_Calculator](https://github.com/warren1001/IAS_Calculator/blob/master/constants.js) — confirms that Werebear Maul has its own per-level skill IAS bonus on top of the wereform baseline, which is what pushes EIAS to the cap with reasonable gear.
- Other Werebear/Werewolf FPDs left untouched; this PR only addresses the reported Maul issue.

## Files changed
- `attackspeedcalc.html`:
  - **BoS input** added at the IAS section (~lines 119-127)
  - **`bosSIAS(slvl)` helper** added near `formSIAS` (~line 851)
  - **`getEffectiveSIAS()`** updated to fold in the BoS contribution for every class (~line 952)
  - **`DRUID_WEREBEAR_FPD["Maul"]`** changed from `16` to `12` (~line 664)
  - **Comment block** above `DRUID_WEREBEAR_FPD` documents the fix and cites the three sources above
  - **How-it-works panel** updated with the new BoS bullet and the 6 fpa Maul cap note

## Test plan
- [ ] Load `attackspeedcalc.html`. Verify the "Burst of Speed Level" input is visible for every class (Amazon, Sorceress, Necromancer, Paladin, Barbarian, Druid, Assassin).
- [ ] Pick Sorceress + any weapon, set BoS Level to 10, confirm the SIAS row jumps from 0 to ~46 and frames drop accordingly.
- [ ] Pick Druid, switch to Werebear form, select Maul. With 0 gear IAS, confirm fpa is reported. Crank Total IAS on Gear up and verify the breakpoint table reaches a minimum of **6 fpa** (previously it floored at 9-10).
- [ ] Confirm the BoS Level input also stacks correctly on top of the auto-applied Werebear shapeshift SIAS.
- [ ] Sanity-check Assassin behaviour didn't regress: pick Assassin + a claw, set BoS Level to 1 (= 21 SIAS) and confirm results match the pre-PR behaviour of typing 21 into the generic Skill IAS box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)