### PR TITLE
Add Necromancer Teeth/Bonespear Ancestral Trial (4:23) clear

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "May 11th 2026",
+  "updatedDate": "May 15th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1887,6 +1887,12 @@ window.soloData = {
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=269&energy=50&coupling=1&skills=000000010000010900000000202000002000200000000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
             "label": "Starter Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=dra_SKo6xJc",
+            "label": "Ancestral Trial (4:23)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "May 11th 2026",
+  "updatedDate": "May 15th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -1887,6 +1887,12 @@
             "url": "https://maaaaaarrk.github.io/pd2_planner/?v=3&url=1&class=necromancer&level=80&difficulty=3&quests=1&strength=91&dexterity=0&vitality=269&energy=50&coupling=1&skills=000000010000010900000000202000002000200000000000000000000000000000&mercenary=Desert+Guard+%C2%AD+%C2%AD+%C2%AD+%C2%AD+%28Defiance%29%2CLore+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Helm%2CStealth+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Armor%2CInsight+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+War+Pike%2Cnone%2Cnone%2Cnone%2Cnone&readonly=1&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&helm=Wormskull%2C1%2Cnone%2C%2C%2C&armor=Spirit+Shroud%2C2%2Cnone%2C%2C%2C%2C%2C%2C&gloves=Trang-Oul%27s+Claws%2C2%2Cnone&boots=Rite+of+Passage%2C2%2Cnone&belt=Gloom%27s+Trap%2C2%2Cnone%2C&amulet=Venomous+Amulet%2C0%2Cnone%2C&ring1=Nagelring%2C0%2Cnone&ring2=Nagelring%2C0%2Cnone&weapon=White+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Tomb+Wand+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C2%2Cnone%2C%2C%2C%2C%2C%2C&offhand=Splendor+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Gargoyle+Head+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Bone+Spear%2C1%2Cnone%2C%2C%2C%2C%2C%2C&merc_helm=none%2C0%2Cnone%2C%2C%2C&merc_armor=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_gloves=none%2C0%2Cnone&merc_boots=none%2C0%2Cnone&merc_belt=none%2C0%2Cnone%2C&merc_weapon=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&merc_offhand=none%2C0%2Cnone%2C%2C%2C%2C%2C%2C&effect=Defiance-mercenary%2C1%2C0&effect=Meditation-mercenary_weapon%2C1%2C0",
             "label": "Starter Build Planner",
             "type": "planner"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=dra_SKo6xJc",
+            "label": "Ancestral Trial (4:23)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []


### PR DESCRIPTION
## Summary

Adds a community-submitted map clear video to the Necromancer Teeth / Bonespear build in the Solo tier list data.

- New link entry under `classBuilds.Necromancer` -> `Teeth / Bonespear` -> `links`:
  - **Ancestral Trial (4:23)** -> https://www.youtube.com/watch?v=dra_SKo6xJc
  - Tagged `season: 13`, type `video` (matching the pattern used for other S13 clear videos in `solo-data.json` / `solo-data.js`).
- Bumped `updatedDate` to `May 15th 2026` in both `solo-data.json` and `solo-data.js` per CLAUDE.md.

Submission by @Mjetap1993.

Closes #228

## Test plan

- [ ] `solo-data.json` parses as valid JSON (verified locally).
- [ ] Visit https://maaaaaarrk.github.io/Hiim-PD2-Resources/solo.html after merge and confirm the new "Ancestral Trial (4:23)" video link appears under the Necromancer Teeth / Bonespear build.
- [ ] Verify the banner shows `Updated -- May 15th 2026`.