### PR TITLE
Add Amazon Jab/Fend video (#231) + bump Frozen Orb (Sorc) to top

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "May 19th 2026",
+  "updatedDate": "May 22nd 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -503,6 +503,18 @@ window.soloData = {
   "classBuilds": {
     "Sorceress": [
       {
+        "buildName": "Frozen Orb",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s",
+            "label": "Starter Guide (59:28)",
+            "type": "video"
+          }
+        ],
+        "notes": []
+      },
+      {
         "buildName": "Nova",
         "tier": "Top",
         "links": [
@@ -588,18 +600,6 @@ window.soloData = {
         "buildName": "Frost Nova",
         "tier": "Good",
         "links": [],
-        "notes": []
-      },
-      {
-        "buildName": "Frozen Orb",
-        "tier": "Good",
-        "links": [
-          {
-            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s",
-            "label": "Starter Guide (59:28)",
-            "type": "video"
-          }
-        ],
         "notes": []
       },
       {
@@ -1588,6 +1588,18 @@ window.soloData = {
             "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=3613s",
             "label": "Build Guide (1:00:13)",
             "type": "video"
+          },
+          {
+            "url": "https://www.projectdiablo2.com/character/Deep_Thrust",
+            "label": "Armory - T3 Cows (12:30)",
+            "type": "armory",
+            "mapLabel": "T3 Cows (12:30)"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=dbZMUXl88lU",
+            "label": "T3 Cows (12:30)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "May 19th 2026",
+  "updatedDate": "May 22nd 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -503,6 +503,18 @@
   "classBuilds": {
     "Sorceress": [
       {
+        "buildName": "Frozen Orb",
+        "tier": "Top",
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s",
+            "label": "Starter Guide (59:28)",
+            "type": "video"
+          }
+        ],
+        "notes": []
+      },
+      {
         "buildName": "Nova",
         "tier": "Top",
         "links": [
@@ -588,18 +600,6 @@
         "buildName": "Frost Nova",
         "tier": "Good",
         "links": [],
-        "notes": []
-      },
-      {
-        "buildName": "Frozen Orb",
-        "tier": "Good",
-        "links": [
-          {
-            "url": "https://www.youtube.com/watch?v=7AAuplKljvg&t=3568s",
-            "label": "Starter Guide (59:28)",
-            "type": "video"
-          }
-        ],
         "notes": []
       },
       {
@@ -1588,6 +1588,18 @@
             "url": "https://www.youtube.com/watch?v=ndPULNORgXM&t=3613s",
             "label": "Build Guide (1:00:13)",
             "type": "video"
+          },
+          {
+            "url": "https://www.projectdiablo2.com/character/Deep_Thrust",
+            "label": "Armory - T3 Cows (12:30)",
+            "type": "armory",
+            "mapLabel": "T3 Cows (12:30)"
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=dbZMUXl88lU",
+            "label": "T3 Cows (12:30)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []


### PR DESCRIPTION
## Summary

- Adds @skorlut's Amazon Jab/Fend T3 cows clear (12:30) submitted in #231, with the per-link `"season": 13` tag and an Armory entry for `Deep_Thrust`.
- Bumps Sorceress Frozen Orb from Good to Top tier and moves it to be the first Top-tier entry in the Sorceress section.
- Updates `updatedDate` to `May 22nd 2026`.
- `solo-data.js` regenerated from `solo-data.json` via `scripts/generate-tier-comparisons.js`.

Closes #231

## Test plan
- [ ] Open `solo.html` and confirm the Amazon Jab/Fend section shows the new T3 Cows (12:30) video link and Armory entry.
- [ ] Confirm Sorceress Frozen Orb appears as the first row in the Top tier.
- [ ] `solo-tier-comparison.txt` regenerated shows `Sorceress - Frozen Orb - Good -> Top`.

Generated with Claude Code