### PR TITLE
Fix #233: add second Amazon Jab/Fend video (T3 cows fortified+ear)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1600,6 +1600,12 @@ window.soloData = {
             "label": "T3 Cows (12:30)",
             "type": "video",
             "season": 13
+          },
+          {
+            "url": "https://youtu.be/TYzfVXLloOw",
+            "label": "T3 Cows fortified+ear (18:00)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []

--- a/solo-data.json
+++ b/solo-data.json
@@ -1600,6 +1600,12 @@
             "label": "T3 Cows (12:30)",
             "type": "video",
             "season": 13
+          },
+          {
+            "url": "https://youtu.be/TYzfVXLloOw",
+            "label": "T3 Cows fortified+ear (18:00)",
+            "type": "video",
+            "season": 13
           }
         ],
         "notes": []


### PR DESCRIPTION
Closes #233

Adds a second video link to the existing Amazon Jab/Fend entry showcasing what the build is really made for: a full T3 Cows clear with fortified + ear corruption in ~18:00. This complements the existing 12:30 normal-T3-cows clear already in the entry from PR #232.

Changes:
- `solo-data.js` / `solo-data.json`: append new link object to the Amazon Jab/Fend `links` array
  - URL: https://youtu.be/TYzfVXLloOw
  - Label: `T3 Cows fortified+ear (18:00)`
  - `type: "video"`, `season: 13` (per the S13 per-link tag convention)

Thanks @skorlut for the submission!