### PR TITLE
Fix #235: mark finpingvin map dmg calc as out of date

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,8 @@ l-22 -19 6 -473 5 -472 -24 -87 c-13 -48 -28 -91 -33 -96 -5 -5 -18 26 -31 75
 					                          class="alert-link">Map Damage
 						Calculator 🔗</a></h5>
 					<p class="card-text">This is a great tool to calculate how many hits it takes to defeat mobs. Takes
-						damage types, player counts, resistances, and even pierce into account.</p>
+						damage types, player counts, resistances, and even pierce into account.
+						<strong>Note: this tool is out of date. Please use the Map Damage Calculator listed above instead.</strong></p>
 				</div>
 			</div>
 			<div class="col-md-6 col-lg-4 card">


### PR DESCRIPTION
Closes #235.

Added a note to the **finpingvin Map Damage Calculator** entry in the *External Resources* section of `index.html`. The entry is an HTML card whose description lives in a `<p class="card-text">`. Appended a `<strong>` note to that paragraph:

> Note: this tool is out of date. Please use the Map Damage Calculator listed above instead.

"The one above" refers to the Hiim-authored Map Damage Calculator card (https://maaaaaarrk.github.io/pd2_maps_explorer/map-dmg-calc.html), which is listed earlier on the page in the tools section. No other links were changed.