### PR TITLE
Add Druid Cold Elemental Sewers map clear (#237)

### DIFF
--- a/solo-data.js
+++ b/solo-data.js
@@ -1,6 +1,6 @@
 window.soloData = {
   "season": 13,
-  "updatedDate": "May 22nd 2026",
+  "updatedDate": "May 30th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -718,7 +718,14 @@ window.soloData = {
       {
         "buildName": "Cold Elemental (Arctic Blast/Hurricane)",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=JpF1nL4ke08",
+            "label": "Sewers of Harrogath (3:30)",
+            "type": "video",
+            "season": 13
+          }
+        ],
         "notes": []
       },
       {

--- a/solo-data.json
+++ b/solo-data.json
@@ -1,6 +1,6 @@
 {
   "season": 13,
-  "updatedDate": "May 22nd 2026",
+  "updatedDate": "May 30th 2026",
   "bannerText": "Updated",
   "starterBuilds": [
     {
@@ -718,7 +718,14 @@
       {
         "buildName": "Cold Elemental (Arctic Blast/Hurricane)",
         "tier": "Good",
-        "links": [],
+        "links": [
+          {
+            "url": "https://www.youtube.com/watch?v=JpF1nL4ke08",
+            "label": "Sewers of Harrogath (3:30)",
+            "type": "video",
+            "season": 13
+          }
+        ],
         "notes": []
       },
       {


### PR DESCRIPTION
Closes #237

## Summary

Adds a new community map-clear video for the **Druid - Cold Elemental (Arctic Blast/Hurricane)** build, submitted by @Maxinskii.

- **Map:** Sewers of Harrogath
- **Clear Time:** 3:30
- **Video:** https://www.youtube.com/watch?v=JpF1nL4ke08

This is the first video link for the Cold Elemental (Arctic Blast/Hurricane) build, so the previously empty `links` array is populated with this entry. The `updatedDate` on `solo-data.json` / `solo-data.js` is bumped to May 30th 2026.

Thanks to @Maxinskii for the submission!

## Test plan

- [ ] `solo.html` loads and shows the new Sewers of Harrogath (3:30) video link under Druid > Cold Elemental (Arctic Blast/Hurricane)
- [ ] Banner shows `Updated — May 30th 2026`
- [ ] `solo-data.json` is valid JSON